### PR TITLE
pause background work

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -531,6 +531,14 @@ void crocksdb_close(crocksdb_t* db) {
   delete db;
 }
 
+void crocksdb_pause_bg_work(crocksdb_t* db) {
+  db->rep->PauseBackgroundWork();
+}
+
+void crocksdb_continue_bg_work(crocksdb_t* db) {
+  db->rep->ContinueBackgroundWork();
+}
+
 crocksdb_t* crocksdb_open_column_families(
     const crocksdb_options_t* db_options,
     const char* name,

--- a/librocksdb_sys/crocksdb/rocksdb/c.h
+++ b/librocksdb_sys/crocksdb/rocksdb/c.h
@@ -202,6 +202,12 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_column_family_handle_destroy(
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_close(crocksdb_t* db);
 
+// This function will wait until all currently running background processes
+// finish. After it returns, no background process will be run until
+// crocksdb_continue_bg_work is called
+extern C_ROCKSDB_LIBRARY_API void crocksdb_pause_bg_work(crocksdb_t* db);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_continue_bg_work(crocksdb_t* db);
+
 extern C_ROCKSDB_LIBRARY_API void crocksdb_put(
     crocksdb_t* db, const crocksdb_writeoptions_t* options, const char* key,
     size_t keylen, const char* val, size_t vallen, char** errptr);

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -255,7 +255,8 @@ extern "C" {
                                                      percentile95: *mut c_double,
                                                      percentile99: *mut c_double,
                                                      average: *mut c_double,
-                                                     standard_deviation: *mut c_double) -> bool;
+                                                     standard_deviation: *mut c_double)
+                                                     -> bool;
     pub fn crocksdb_options_set_stats_dump_period_sec(options: *mut DBOptions, v: usize);
     pub fn crocksdb_options_set_num_levels(options: *mut DBOptions, v: c_int);
     pub fn crocksdb_options_set_db_log_dir(options: *mut DBOptions, path: *const c_char);
@@ -349,6 +350,8 @@ extern "C" {
                                      kLen: size_t,
                                      err: *mut *mut c_char);
     pub fn crocksdb_close(db: *mut DBInstance);
+    pub fn crocksdb_pause_bg_work(db: *mut DBInstance);
+    pub fn crocksdb_continue_bg_work(db: *mut DBInstance);
     pub fn crocksdb_destroy_db(options: *const DBOptions,
                                path: *const c_char,
                                err: *mut *mut c_char);


### PR DESCRIPTION
Call `pause_bg_work` will wait until all currently running background processes finish, this will guarantee that there is no rocksdb's background threads. 
@BusyJay @siddontang PTAL