### PR TITLE
soft/hard pending compaction bytes limit

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -1885,6 +1885,14 @@ void crocksdb_options_set_hard_rate_limit(crocksdb_options_t* opt, double v) {
   opt->rep.hard_rate_limit = v;
 }
 
+void crocksdb_options_set_soft_pending_compaction_bytes_limit(crocksdb_options_t* opt, size_t v) {
+  opt->rep.soft_pending_compaction_bytes_limit = v;
+}
+
+void crocksdb_options_set_hard_pending_compaction_bytes_limit(crocksdb_options_t* opt, size_t v) {
+  opt->rep.hard_pending_compaction_bytes_limit = v;
+}
+
 void crocksdb_options_set_rate_limit_delay_max_milliseconds(
     crocksdb_options_t* opt, unsigned int v) {
   opt->rep.rate_limit_delay_max_milliseconds = v;

--- a/librocksdb_sys/crocksdb/rocksdb/c.h
+++ b/librocksdb_sys/crocksdb/rocksdb/c.h
@@ -667,6 +667,10 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_soft_rate_limit(
     crocksdb_options_t*, double);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_hard_rate_limit(
     crocksdb_options_t*, double);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_soft_pending_compaction_bytes_limit(
+    crocksdb_options_t* opt, size_t v);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_hard_pending_compaction_bytes_limit(
+    crocksdb_options_t* opt, size_t v);
 extern C_ROCKSDB_LIBRARY_API void
 crocksdb_options_set_rate_limit_delay_max_milliseconds(crocksdb_options_t*,
                                                       unsigned int);

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -266,6 +266,10 @@ extern "C" {
                                                  prefix_extractor: *mut DBSliceTransform);
     pub fn crocksdb_options_set_memtable_prefix_bloom_size_ratio(options: *mut DBOptions,
                                                                  ratio: c_double);
+    pub fn crocksdb_options_set_soft_pending_compaction_bytes_limit(options: *mut DBOptions,
+                                                                    v: u64);
+    pub fn crocksdb_options_set_hard_pending_compaction_bytes_limit(options: *mut DBOptions,
+                                                                    v: u64);
     pub fn crocksdb_filterpolicy_create_bloom_full(bits_per_key: c_int) -> *mut DBFilterPolicy;
     pub fn crocksdb_filterpolicy_create_bloom(bits_per_key: c_int) -> *mut DBFilterPolicy;
     pub fn crocksdb_open(options: *mut DBOptions,

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -441,6 +441,20 @@ impl Options {
         }
     }
 
+    pub fn set_soft_pending_compaction_bytes_limit(&mut self, size: u64) {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_soft_pending_compaction_bytes_limit(self.inner,
+                                                                                   size);
+        }
+    }
+
+    pub fn set_hard_pending_compaction_bytes_limit(&mut self, size: u64) {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_hard_pending_compaction_bytes_limit(self.inner,
+                                                                                   size);
+        }
+    }
+
     pub fn set_max_manifest_file_size(&mut self, size: u64) {
         unsafe {
             crocksdb_ffi::crocksdb_options_set_max_manifest_file_size(self.inner, size);


### PR DESCRIPTION
If estimated bytes need to be compaction exceed `soft_pending_compaction_bytes_limit` write will be slowed down, exceed `soft_pending_compaction_bytes_limit` all writes are stopped.
@siddontang @ngaut PTAL