### PR TITLE
remove useless rocksdb API

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -1466,11 +1466,6 @@ void crocksdb_block_based_options_set_pin_l0_filter_and_index_blocks_in_cache(
   options->rep.pin_l0_filter_and_index_blocks_in_cache = v;
 }
 
-void crocksdb_block_based_options_set_skip_table_builder_flush(
-    crocksdb_block_based_table_options_t* options, unsigned char v) {
-  options->rep.skip_table_builder_flush = v;
-}
-
 void crocksdb_options_set_block_based_table_factory(
     crocksdb_options_t *opt,
     crocksdb_block_based_table_options_t* table_options) {
@@ -1737,11 +1732,6 @@ void crocksdb_options_set_memtable_insert_with_hint_prefix_extractor(
   opt->rep.memtable_insert_with_hint_prefix_extractor.reset(prefix_extractor);
 }
 
-void crocksdb_options_set_disable_data_sync(
-    crocksdb_options_t* opt, int disable_data_sync) {
-  opt->rep.disableDataSync = disable_data_sync;
-}
-
 void crocksdb_options_set_use_fsync(
     crocksdb_options_t* opt, int use_fsync) {
   opt->rep.use_fsync = use_fsync;
@@ -1841,11 +1831,6 @@ void crocksdb_options_set_allow_concurrent_memtable_write(crocksdb_options_t* op
 void crocksdb_options_set_enable_write_thread_adaptive_yield(
     crocksdb_options_t* opt, unsigned char v) {
   opt->rep.enable_write_thread_adaptive_yield = v;
-}
-
-void crocksdb_options_set_verify_checksums_in_compaction(
-    crocksdb_options_t* opt, unsigned char v) {
-  opt->rep.verify_checksums_in_compaction = v;
 }
 
 void crocksdb_options_set_max_sequential_skip_in_iterations(
@@ -1985,11 +1970,6 @@ void crocksdb_options_set_plain_table_factory(
 void crocksdb_options_set_max_successive_merges(
     crocksdb_options_t* opt, size_t v) {
   opt->rep.max_successive_merges = v;
-}
-
-void crocksdb_options_set_min_partial_merge_operands(
-    crocksdb_options_t* opt, uint32_t v) {
-  opt->rep.min_partial_merge_operands = v;
 }
 
 void crocksdb_options_set_bloom_locality(

--- a/librocksdb_sys/crocksdb/rocksdb/c.h
+++ b/librocksdb_sys/crocksdb/rocksdb/c.h
@@ -524,9 +524,6 @@ crocksdb_block_based_options_set_cache_index_and_filter_blocks(
 extern C_ROCKSDB_LIBRARY_API void
 crocksdb_block_based_options_set_pin_l0_filter_and_index_blocks_in_cache(
     crocksdb_block_based_table_options_t*, unsigned char);
-extern C_ROCKSDB_LIBRARY_API void
-crocksdb_block_based_options_set_skip_table_builder_flush(
-    crocksdb_block_based_table_options_t* options, unsigned char);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_block_based_table_factory(
     crocksdb_options_t* opt, crocksdb_block_based_table_options_t* table_options);
 
@@ -728,13 +725,8 @@ extern C_ROCKSDB_LIBRARY_API void
 crocksdb_options_set_enable_write_thread_adaptive_yield(crocksdb_options_t*,
                                                        unsigned char);
 extern C_ROCKSDB_LIBRARY_API void
-crocksdb_options_set_verify_checksums_in_compaction(crocksdb_options_t*,
-                                                   unsigned char);
-extern C_ROCKSDB_LIBRARY_API void
 crocksdb_options_set_max_sequential_skip_in_iterations(crocksdb_options_t*,
                                                       uint64_t);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_disable_data_sync(
-    crocksdb_options_t*, int);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_disable_auto_compactions(
     crocksdb_options_t*, int);
 extern C_ROCKSDB_LIBRARY_API void
@@ -763,8 +755,6 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_memtable_huge_page_size(
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_max_successive_merges(
     crocksdb_options_t*, size_t);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_min_partial_merge_operands(
-    crocksdb_options_t*, uint32_t);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_bloom_locality(
     crocksdb_options_t*, uint32_t);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_inplace_update_support(

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -200,7 +200,6 @@ extern "C" {
     pub fn crocksdb_options_set_max_total_wal_size(options: *mut DBOptions, size: u64);
     pub fn crocksdb_options_set_use_fsync(options: *mut DBOptions, v: c_int);
     pub fn crocksdb_options_set_bytes_per_sync(options: *mut DBOptions, bytes: u64);
-    pub fn crocksdb_options_set_disable_data_sync(options: *mut DBOptions, v: c_int);
     pub fn crocksdb_options_optimize_for_point_lookup(options: *mut DBOptions,
                                                       block_cache_size_mb: u64);
     pub fn crocksdb_options_set_table_cache_numshardbits(options: *mut DBOptions, bits: c_int);

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,6 @@ mod tests {
         opts.set_max_open_files(10000);
         opts.set_use_fsync(false);
         opts.set_bytes_per_sync(8388608);
-        opts.set_disable_data_sync(false);
         opts.set_block_cache_size_mb(1024);
         opts.set_table_cache_num_shard_bits(6);
         opts.set_max_write_buffer_number(32);

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -420,16 +420,6 @@ impl Options {
         }
     }
 
-    pub fn set_disable_data_sync(&mut self, disable: bool) {
-        unsafe {
-            if disable {
-                crocksdb_ffi::crocksdb_options_set_disable_data_sync(self.inner, 1);
-            } else {
-                crocksdb_ffi::crocksdb_options_set_disable_data_sync(self.inner, 0);
-            }
-        }
-    }
-
     pub fn set_table_cache_num_shard_bits(&mut self, nbits: c_int) {
         unsafe {
             crocksdb_ffi::crocksdb_options_set_table_cache_numshardbits(self.inner, nbits);


### PR DESCRIPTION
Some options are removed from RocksDB 5.2+, removing these is ok and has no problem with 5.1, only we need to remove `set_disable_data_sync` in TiKV later. 

@BusyJay @hhkbp2 @zhangjinpeng1987 