### PR TITLE
Add RocksDB options for in memory configurations.

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -1771,11 +1771,11 @@ void crocksdb_options_set_wal_dir(
   opt->rep.wal_dir = v;
 }
 
-void crocksdb_options_set_WAL_ttl_seconds(crocksdb_options_t* opt, uint64_t ttl) {
+void crocksdb_options_set_wal_ttl_seconds(crocksdb_options_t* opt, uint64_t ttl) {
   opt->rep.WAL_ttl_seconds = ttl;
 }
 
-void crocksdb_options_set_WAL_size_limit_MB(
+void crocksdb_options_set_wal_size_limit_mb(
     crocksdb_options_t* opt, uint64_t limit) {
   opt->rep.WAL_size_limit_MB = limit;
 }

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -2379,7 +2379,7 @@ void crocksdb_writeoptions_set_sync(
   opt->rep.sync = v;
 }
 
-void crocksdb_writeoptions_disable_WAL(crocksdb_writeoptions_t* opt, int disable) {
+void crocksdb_writeoptions_disable_wal(crocksdb_writeoptions_t* opt, int disable) {
   opt->rep.disableWAL = disable;
 }
 

--- a/librocksdb_sys/crocksdb/rocksdb/c.h
+++ b/librocksdb_sys/crocksdb/rocksdb/c.h
@@ -938,7 +938,7 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_writeoptions_destroy(
     crocksdb_writeoptions_t*);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_writeoptions_set_sync(
     crocksdb_writeoptions_t*, unsigned char);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_writeoptions_disable_WAL(
+extern C_ROCKSDB_LIBRARY_API void crocksdb_writeoptions_disable_wal(
     crocksdb_writeoptions_t* opt, int disable);
 
 /* Compact range options */

--- a/librocksdb_sys/crocksdb/rocksdb/c.h
+++ b/librocksdb_sys/crocksdb/rocksdb/c.h
@@ -700,9 +700,9 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_db_log_dir(
     crocksdb_options_t*, const char*);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_wal_dir(crocksdb_options_t*,
                                                             const char*);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_WAL_ttl_seconds(
+extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_wal_ttl_seconds(
     crocksdb_options_t*, uint64_t);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_WAL_size_limit_MB(
+extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_wal_size_limit_mb(
     crocksdb_options_t*, uint64_t);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_manifest_preallocation_size(
     crocksdb_options_t*, size_t);

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -264,8 +264,8 @@ extern "C" {
     pub fn crocksdb_options_set_num_levels(options: *mut DBOptions, v: c_int);
     pub fn crocksdb_options_set_db_log_dir(options: *mut DBOptions, path: *const c_char);
     pub fn crocksdb_options_set_wal_dir(options: *mut DBOptions, path: *const c_char);
-    pub fn crocksdb_options_set_WAL_ttl_seconds(options: *mut DBOptions, ttl: u64);
-    pub fn crocksdb_options_set_WAL_size_limit_MB(options: *mut DBOptions, limit: u64);
+    pub fn crocksdb_options_set_wal_ttl_seconds(options: *mut DBOptions, ttl: u64);
+    pub fn crocksdb_options_set_wal_size_limit_mb(options: *mut DBOptions, limit: u64);
     pub fn crocksdb_options_set_prefix_extractor(options: *mut DBOptions,
                                                  prefix_extractor: *mut DBSliceTransform);
     pub fn crocksdb_options_set_memtable_insert_with_hint_prefix_extractor(options: *mut DBOptions,

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -287,7 +287,7 @@ extern "C" {
     pub fn crocksdb_writeoptions_create() -> *mut DBWriteOptions;
     pub fn crocksdb_writeoptions_destroy(writeopts: *mut DBWriteOptions);
     pub fn crocksdb_writeoptions_set_sync(writeopts: *mut DBWriteOptions, v: bool);
-    pub fn crocksdb_writeoptions_disable_WAL(writeopts: *mut DBWriteOptions, v: c_int);
+    pub fn crocksdb_writeoptions_disable_wal(writeopts: *mut DBWriteOptions, v: c_int);
     pub fn crocksdb_put(db: *mut DBInstance,
                         writeopts: *mut DBWriteOptions,
                         k: *const u8,

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -263,6 +263,9 @@ extern "C" {
     pub fn crocksdb_options_set_stats_dump_period_sec(options: *mut DBOptions, v: usize);
     pub fn crocksdb_options_set_num_levels(options: *mut DBOptions, v: c_int);
     pub fn crocksdb_options_set_db_log_dir(options: *mut DBOptions, path: *const c_char);
+    pub fn crocksdb_options_set_wal_dir(options: *mut DBOptions, path: *const c_char);
+    pub fn crocksdb_options_set_WAL_ttl_seconds(options: *mut DBOptions, ttl: u64);
+    pub fn crocksdb_options_set_WAL_size_limit_MB(options: *mut DBOptions, limit: u64);
     pub fn crocksdb_options_set_prefix_extractor(options: *mut DBOptions,
                                                  prefix_extractor: *mut DBSliceTransform);
     pub fn crocksdb_options_set_memtable_insert_with_hint_prefix_extractor(options: *mut DBOptions,

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -246,9 +246,9 @@ impl WriteOptions {
     pub fn disable_wal(&mut self, disable: bool) {
         unsafe {
             if disable {
-                crocksdb_ffi::crocksdb_writeoptions_disable_WAL(self.inner, 1);
+                crocksdb_ffi::crocksdb_writeoptions_disable_wal(self.inner, 1);
             } else {
-                crocksdb_ffi::crocksdb_writeoptions_disable_WAL(self.inner, 0);
+                crocksdb_ffi::crocksdb_writeoptions_disable_wal(self.inner, 0);
             }
         }
     }

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -663,13 +663,13 @@ impl Options {
 
     pub fn set_wal_ttl_seconds(&mut self, ttl: u64) {
         unsafe {
-            crocksdb_ffi::crocksdb_options_set_WAL_ttl_seconds(self.inner, ttl as u64);
+            crocksdb_ffi::crocksdb_options_set_wal_ttl_seconds(self.inner, ttl as u64);
         }
     }
 
     pub fn set_wal_size_limit_mb(&mut self, limit: u64) {
         unsafe {
-            crocksdb_ffi::crocksdb_options_set_WAL_size_limit_MB(self.inner, limit as u64);
+            crocksdb_ffi::crocksdb_options_set_wal_size_limit_mb(self.inner, limit as u64);
         }
     }
 

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -654,6 +654,25 @@ impl Options {
         }
     }
 
+    pub fn set_wal_dir(&mut self, path: &str) {
+        let path = CString::new(path.as_bytes()).unwrap();
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_wal_dir(self.inner, path.as_ptr());
+        }
+    }
+
+    pub fn set_wal_ttl_seconds(&mut self, ttl: u64) {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_WAL_ttl_seconds(self.inner, ttl as u64);
+        }
+    }
+
+    pub fn set_wal_size_limit_mb(&mut self, limit: u64) {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_WAL_size_limit_MB(self.inner, limit as u64);
+        }
+    }
+
     pub fn set_max_log_file_size(&mut self, size: u64) {
         unsafe {
             crocksdb_ffi::crocksdb_options_set_max_log_file_size(self.inner, size as size_t);

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -118,3 +118,17 @@ fn test_set_ratelimiter() {
     let db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
     drop(db);
 }
+
+#[test]
+fn test_set_wal_opt() {
+    let path = TempDir::new("_rust_rocksdb_test_set_wal_opt").expect("");
+    let mut opts = Options::new();
+    opts.create_if_missing(true);
+    opts.set_wal_ttl_seconds(86400);
+    opts.set_wal_size_limit_mb(10);
+    let wal_dir = TempDir::new("_rust_rocksdb_test_set_wal_dir").expect("");
+    opts.set_wal_dir(wal_dir.path().to_str().unwrap());
+    let db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
+    drop(db);
+}
+


### PR DESCRIPTION
When you set the path to rocksdb directory in memory like in /dev/shm,
you need to set the wal_dir and WAL_ttl_seconds options if you want to
recover your in-memory RocksDB database after a machine reboot.

See: https://github.com/facebook/rocksdb/wiki/How-to-persist-in-memory-RocksDB-database