### PR TITLE
create info log

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -2788,4 +2788,18 @@ void crocksdb_delete_file_in_range_cf(
 
 void crocksdb_free(void* ptr) { free(ptr); }
 
+crocksdb_logger_t* crocksdb_create_log_from_options(
+    const char* path, crocksdb_options_t* opts, char** errptr) {
+    crocksdb_logger_t* logger = new crocksdb_logger_t;
+    if(SaveError(
+      errptr,
+      CreateLoggerFromOptions(
+        std::string(path), opts->rep, &logger->rep))) {
+      delete logger;
+      return NULL;
+    }
+
+    return logger;
+}
+
 }  // end extern "C"

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -2802,4 +2802,9 @@ crocksdb_logger_t* crocksdb_create_log_from_options(
     return logger;
 }
 
+void crocksdb_log_destroy(
+    crocksdb_logger_t* logger) {
+    delete logger;
+}
+
 }  // end extern "C"

--- a/librocksdb_sys/crocksdb/rocksdb/c.h
+++ b/librocksdb_sys/crocksdb/rocksdb/c.h
@@ -1125,6 +1125,9 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_delete_file_in_range_cf(
 // to free memory that was malloc()ed
 extern C_ROCKSDB_LIBRARY_API void crocksdb_free(void* ptr);
 
+extern C_ROCKSDB_LIBRARY_API crocksdb_logger_t* crocksdb_create_log_from_options(
+    const char* path, crocksdb_options_t* opts, char** errptr);
+
 #ifdef __cplusplus
 }  /* end extern "C" */
 #endif

--- a/librocksdb_sys/crocksdb/rocksdb/c.h
+++ b/librocksdb_sys/crocksdb/rocksdb/c.h
@@ -1127,7 +1127,8 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_free(void* ptr);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_logger_t* crocksdb_create_log_from_options(
     const char* path, crocksdb_options_t* opts, char** errptr);
-
+extern C_ROCKSDB_LIBRARY_API void crocksdb_log_destroy(
+    crocksdb_logger_t*);
 #ifdef __cplusplus
 }  /* end extern "C" */
 #endif

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -42,6 +42,7 @@ pub enum DBBackupEngine {}
 pub enum DBRestoreOptions {}
 pub enum DBSliceTransform {}
 pub enum DBRateLimiter {}
+pub enum DBLogger {}
 
 pub fn new_bloom_filter(bits: c_int) -> *mut DBFilterPolicy {
     unsafe { crocksdb_filterpolicy_create_bloom(bits) }
@@ -273,6 +274,7 @@ extern "C" {
     pub fn crocksdb_options_set_memtable_prefix_bloom_size_ratio(options: *mut DBOptions,
                                                                  ratio: c_double);
     pub fn crocksdb_options_set_ratelimiter(options: *mut DBOptions, limiter: *mut DBRateLimiter);
+    pub fn crocksdb_options_set_info_log(options: *mut DBOptions, logger: *mut DBLogger);
     pub fn crocksdb_ratelimiter_create(rate_bytes_per_sec: i64,
                                        refill_period_us: i64,
                                        fairness: i32)
@@ -703,6 +705,10 @@ extern "C" {
                                           name: extern "C" fn(*mut c_void) -> *const c_char)
                                           -> *mut DBSliceTransform;
     pub fn crocksdb_slicetransform_destroy(transform: *mut DBSliceTransform);
+    pub fn crocksdb_create_log_from_options(path: *const c_char,
+                                            options: *mut DBOptions,
+                                            err: *mut *mut c_char)
+                                            -> *mut DBLogger;
 }
 
 #[cfg(test)]

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -709,6 +709,7 @@ extern "C" {
                                             options: *mut DBOptions,
                                             err: *mut *mut c_char)
                                             -> *mut DBLogger;
+    pub fn crocksdb_log_destroy(logger: *mut DBLogger);
 }
 
 #[cfg(test)]

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -756,6 +756,7 @@ impl Options {
         unsafe {
             let logger = ffi_try!(crocksdb_create_log_from_options(cpath.as_ptr(), self.inner));
             crocksdb_ffi::crocksdb_options_set_info_log(self.inner, logger);
+            crocksdb_ffi::crocksdb_log_destroy(logger);
         }
 
         Ok(())

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -756,6 +756,7 @@ impl Options {
         unsafe {
             let logger = ffi_try!(crocksdb_create_log_from_options(cpath.as_ptr(), self.inner));
             crocksdb_ffi::crocksdb_options_set_info_log(self.inner, logger);
+            // logger uses shared_ptr, it is OK to destroy here.
             crocksdb_ffi::crocksdb_log_destroy(logger);
         }
 

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -741,6 +741,25 @@ impl Options {
             crocksdb_ffi::crocksdb_options_set_ratelimiter(self.inner, rate_limiter.inner);
         }
     }
+
+    // Create a info log with `path` and save to options logger field directly.
+    // TODO: export more logger options like level, roll size, time, etc...
+    pub fn create_info_log(&self, path: &str) -> Result<(), String> {
+        let cpath = match CString::new(path.as_bytes()) {
+            Ok(c) => c,
+            Err(_) => {
+                return Err("Failed to convert path to CString when creating rocksdb info log"
+                    .to_owned())
+            }
+        };
+
+        unsafe {
+            let logger = ffi_try!(crocksdb_create_log_from_options(cpath.as_ptr(), self.inner));
+            crocksdb_ffi::crocksdb_options_set_info_log(self.inner, logger);
+        }
+
+        Ok(())
+    }
 }
 
 pub struct FlushOptions {

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -132,3 +132,16 @@ fn test_set_wal_opt() {
     drop(db);
 }
 
+#[test]
+fn test_create_info_log() {
+    let path = TempDir::new("_rust_rocksdb_test_create_info_log_opt").expect("");
+    let mut opts = Options::new();
+    opts.create_if_missing(true);
+
+    let info_dir = TempDir::new("_rust_rocksdb_test_info_log_dir").expect("");
+    let info_path = info_dir.path().join("LOG");
+    opts.create_info_log(info_path.to_str().unwrap()).unwrap();
+    let db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
+
+    drop(db);
+}

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -139,8 +139,7 @@ fn test_create_info_log() {
     opts.create_if_missing(true);
 
     let info_dir = TempDir::new("_rust_rocksdb_test_info_log_dir").expect("");
-    let info_path = info_dir.path().join("LOG");
-    opts.create_info_log(info_path.to_str().unwrap()).unwrap();
+    opts.create_info_log(info_dir.path().to_str().unwrap()).unwrap();
     let db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
 
     drop(db);

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -14,6 +14,7 @@
 use rocksdb::{DB, Options, WriteOptions, SliceTransform};
 use rocksdb::crocksdb_ffi::{DBStatisticsHistogramType as HistogramType,
                             DBStatisticsTickerType as TickerType};
+use std::path::Path;
 use tempdir::TempDir;
 
 
@@ -141,6 +142,8 @@ fn test_create_info_log() {
     let info_dir = TempDir::new("_rust_rocksdb_test_info_log_dir").expect("");
     opts.create_info_log(info_dir.path().to_str().unwrap()).unwrap();
     let db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
+
+    assert!(Path::new(info_dir.path().join("LOG").to_str().unwrap()).is_file());
 
     drop(db);
 }


### PR DESCRIPTION
We can use create_info_log to let RocksDB generate info LOG to other places with special name.

@BusyJay @overvenus @zhangjinpeng1987 