### PR TITLE
Get block cache usage size

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -1053,12 +1053,6 @@ void crocksdb_enable_file_deletions(
   SaveError(errptr, db->rep->EnableFileDeletions(force));
 }
 
-crocksdb_options_t* crocksdb_get_options(const crocksdb_t* db) {
-  crocksdb_options_t* options = new crocksdb_options_t;
-  options->rep = db->rep->GetOptions();
-  return options;
-}
-
 crocksdb_options_t* crocksdb_get_options_cf(
     const crocksdb_t* db,
     crocksdb_column_family_handle_t* column_family) {
@@ -1489,6 +1483,17 @@ void crocksdb_options_set_block_based_table_factory(
   }
 }
 
+size_t crocksdb_options_get_block_cache_usage(crocksdb_options_t *opt) {
+  if (opt) {
+    if (opt->rep.table_factory != nullptr) {
+      void* block_based_table_opt = opt->rep.table_factory->GetOptions();
+      if (block_based_table_opt) {
+        return static_cast<BlockBasedTableOptions*>(block_based_table_opt)->block_cache->GetUsage();
+      }
+    }
+  }
+  return 0;
+}
 
 crocksdb_cuckoo_table_options_t*
 crocksdb_cuckoo_options_create() {

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -1486,9 +1486,9 @@ void crocksdb_options_set_block_based_table_factory(
 size_t crocksdb_options_get_block_cache_usage(crocksdb_options_t *opt) {
   if (opt) {
     if (opt->rep.table_factory != nullptr) {
-      void* block_based_table_opt = opt->rep.table_factory->GetOptions();
-      if (block_based_table_opt) {
-        return static_cast<BlockBasedTableOptions*>(block_based_table_opt)->block_cache->GetUsage();
+      void* table_opt = opt->rep.table_factory->GetOptions();
+      if (table_opt && strcmp(opt->rep.table_factory->Name(), "BlockBasedTable") == 0) {
+        return static_cast<BlockBasedTableOptions*>(table_opt)->block_cache->GetUsage();
       }
     }
   }

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -85,6 +85,8 @@ using std::shared_ptr;
 
 extern "C" {
 
+const char* block_base_table_str = "BlockBasedTable";
+
 struct crocksdb_t                 { DB*               rep; };
 struct crocksdb_backup_engine_t   { BackupEngine*     rep; };
 struct crocksdb_backup_engine_info_t { std::vector<BackupInfo> rep; };
@@ -1484,12 +1486,10 @@ void crocksdb_options_set_block_based_table_factory(
 }
 
 size_t crocksdb_options_get_block_cache_usage(crocksdb_options_t *opt) {
-  if (opt) {
-    if (opt->rep.table_factory != nullptr) {
-      void* table_opt = opt->rep.table_factory->GetOptions();
-      if (table_opt && strcmp(opt->rep.table_factory->Name(), "BlockBasedTable") == 0) {
-        return static_cast<BlockBasedTableOptions*>(table_opt)->block_cache->GetUsage();
-      }
+  if (opt && opt->rep.table_factory != nullptr) {
+    void* table_opt = opt->rep.table_factory->GetOptions();
+    if (table_opt && strcmp(opt->rep.table_factory->Name(), block_base_table_str) == 0) {
+      return static_cast<BlockBasedTableOptions*>(table_opt)->block_cache->GetUsage();
     }
   }
   return 0;

--- a/librocksdb_sys/crocksdb/rocksdb/c.h
+++ b/librocksdb_sys/crocksdb/rocksdb/c.h
@@ -362,9 +362,6 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_disable_file_deletions(crocksdb_t* db
 extern C_ROCKSDB_LIBRARY_API void crocksdb_enable_file_deletions(
     crocksdb_t* db, unsigned char force, char** errptr);
 
-extern C_ROCKSDB_LIBRARY_API crocksdb_options_t* crocksdb_get_options(
-    const crocksdb_t* db);
-
 extern C_ROCKSDB_LIBRARY_API crocksdb_options_t* crocksdb_get_options_cf(
     const crocksdb_t* db, crocksdb_column_family_handle_t* column_family);
 
@@ -532,6 +529,9 @@ crocksdb_block_based_options_set_pin_l0_filter_and_index_blocks_in_cache(
     crocksdb_block_based_table_options_t*, unsigned char);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_block_based_table_factory(
     crocksdb_options_t* opt, crocksdb_block_based_table_options_t* table_options);
+
+extern C_ROCKSDB_LIBRARY_API size_t crocksdb_options_get_block_cache_usage(
+    crocksdb_options_t *opt);
 
 /* Cuckoo table options */
 

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -171,7 +171,6 @@ macro_rules! ffi_try {
 // TODO audit the use of boolean arguments, b/c I think they need to be u8
 // instead...
 extern "C" {
-    pub fn crocksdb_get_options(db: *mut DBInstance) -> *mut DBOptions;
     pub fn crocksdb_get_options_cf(db: *mut DBInstance, cf: *mut DBCFHandle) -> *mut DBOptions;
     pub fn crocksdb_options_create() -> *mut DBOptions;
     pub fn crocksdb_options_destroy(opts: *mut DBOptions);
@@ -290,6 +289,7 @@ extern "C" {
                                                                  ratio: c_double);
     pub fn crocksdb_options_set_ratelimiter(options: *mut DBOptions, limiter: *mut DBRateLimiter);
     pub fn crocksdb_options_set_info_log(options: *mut DBOptions, logger: *mut DBLogger);
+    pub fn crocksdb_options_get_block_cache_usage(options: *const DBOptions) -> usize;
     pub fn crocksdb_ratelimiter_create(rate_bytes_per_sec: i64,
                                        refill_period_us: i64,
                                        fairness: i32)

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -72,8 +72,8 @@ pub enum DBCompactionStyle {
 
 #[repr(C)]
 pub enum DBUniversalCompactionStyle {
-    SimilarSizeCompactionStopStyle = 0,
-    TotalSizeCompactionStopStyle = 1,
+    SimilarSize = 0,
+    TotalSize = 1,
 }
 
 #[derive(Copy, Clone, PartialEq)]

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -72,8 +72,8 @@ pub enum DBCompactionStyle {
 
 #[repr(C)]
 pub enum DBUniversalCompactionStyle {
-    crocksdb_similar_size_compaction_stop_style = 0,
-    crocksdb_total_size_compaction_stop_style = 1,
+    SimilarSizeCompactionStopStyle = 0,
+    TotalSizeCompactionStopStyle = 1,
 }
 
 #[derive(Copy, Clone, PartialEq)]

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -772,6 +772,12 @@ impl Options {
 
         Ok(())
     }
+
+    pub fn get_block_cache_usage(&self) -> u64 {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_get_block_cache_usage(self.inner) as u64
+        }
+    }
 }
 
 pub struct FlushOptions {

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -194,3 +194,27 @@ fn test_set_pin_l0_filter_and_index_blocks_in_cache() {
     let db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
     drop(db);
 }
+
+#[test]
+fn test_get_block_cache_usage() {
+    let path = TempDir::new("_rust_rocksdb_set_cache_and_index").expect("");
+    let mut opts = Options::new();
+    opts.create_if_missing(true);
+    let mut block_opts = BlockBasedOptions::new();
+    block_opts.set_lru_cache(16 * 1024 * 1024);
+    opts.set_block_based_table_factory(&block_opts);
+    let db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
+
+    for i in 0..200 {
+        db.put(format!("k_{}", i).as_bytes(), b"v").unwrap();
+    }
+    db.flush(true).unwrap();
+    for i in 0..200 {
+        db.get(format!("k_{}", i).as_bytes()).unwrap();
+    }
+
+    assert!(db.get_options().get_block_cache_usage() > 0);
+
+    let opts = Options::new();
+    assert_eq!(opts.get_block_cache_usage(), 0);
+}

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -191,8 +191,7 @@ fn test_set_pin_l0_filter_and_index_blocks_in_cache() {
     let mut block_opts = BlockBasedOptions::new();
     block_opts.set_pin_l0_filter_and_index_blocks_in_cache(true);
     opts.set_block_based_table_factory(&block_opts);
-    let db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
-    drop(db);
+    DB::open(opts, path.path().to_str().unwrap()).unwrap();
 }
 #[test]
 fn test_pending_compaction_bytes_limit() {
@@ -201,7 +200,7 @@ fn test_pending_compaction_bytes_limit() {
     opts.create_if_missing(true);
     opts.set_soft_pending_compaction_bytes_limit(64 * 1024 * 1024 * 1024);
     opts.set_hard_pending_compaction_bytes_limit(256 * 1024 * 1024 * 1024);
-    let db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
+    DB::open(opts, path.path().to_str().unwrap()).unwrap();
 }
 
 #[test]
@@ -213,11 +212,13 @@ fn test_set_max_subcompactions() {
     DB::open(opts, path.path().to_str().unwrap()).unwrap();
 }
 
-
 #[test]
 fn test_get_block_cache_usage() {
     let path = TempDir::new("_rust_rocksdb_set_cache_and_index").expect("");
+
     let mut opts = Options::new();
+    assert_eq!(opts.get_block_cache_usage(), 0);
+
     opts.create_if_missing(true);
     let mut block_opts = BlockBasedOptions::new();
     block_opts.set_lru_cache(16 * 1024 * 1024);
@@ -233,7 +234,4 @@ fn test_get_block_cache_usage() {
     }
 
     assert!(db.get_options().get_block_cache_usage() > 0);
-
-    let opts = Options::new();
-    assert_eq!(opts.get_block_cache_usage(), 0);
 }


### PR DESCRIPTION
1) Get block cache usage size. 
2) `crocksdb_get_options ` not return `rocksdb::Options` for `default` cf but return `rocksdb::DBOptions`, so we implement `get_options` by `get_options_cf`.
@siddontang @BusyJay PTAL