### PR TITLE
*: implement debug for DB

### DIFF
--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -52,6 +52,12 @@ pub struct DB {
     opts: Options,
 }
 
+impl Debug for DB {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "Db [path={}]", self.path)
+    }
+}
+
 unsafe impl Send for DB {}
 unsafe impl Sync for DB {}
 


### PR DESCRIPTION
So that we can use `#[derive(Debug)]` for structs that contains `DB`.

@siddontang @zhangjinpeng1987 PTAL