### PR TITLE
add constructor for sstfilewriter

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -2482,6 +2482,14 @@ crocksdb_envoptions_t* crocksdb_envoptions_create() {
 void crocksdb_envoptions_destroy(crocksdb_envoptions_t* opt) { delete opt; }
 
 crocksdb_sstfilewriter_t* crocksdb_sstfilewriter_create(
+    const crocksdb_envoptions_t* env, const crocksdb_options_t* io_options) {
+  crocksdb_sstfilewriter_t* writer = new crocksdb_sstfilewriter_t;
+  writer->rep =
+      new SstFileWriter(env->rep, io_options->rep, io_options->rep.comparator);
+  return writer;
+}
+
+crocksdb_sstfilewriter_t* crocksdb_sstfilewriter_create_cf(
     const crocksdb_envoptions_t* env, const crocksdb_options_t* io_options,
     crocksdb_column_family_handle_t* column_family) {
   crocksdb_sstfilewriter_t* writer = new crocksdb_sstfilewriter_t;

--- a/librocksdb_sys/crocksdb/rocksdb/c.h
+++ b/librocksdb_sys/crocksdb/rocksdb/c.h
@@ -994,6 +994,9 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_envoptions_destroy(
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_sstfilewriter_t*
 crocksdb_sstfilewriter_create(const crocksdb_envoptions_t* env,
+                              const crocksdb_options_t* io_options);
+extern C_ROCKSDB_LIBRARY_API crocksdb_sstfilewriter_t*
+crocksdb_sstfilewriter_create_cf(const crocksdb_envoptions_t* env,
                              const crocksdb_options_t* io_options,
                              crocksdb_column_family_handle_t* column_family);
 extern C_ROCKSDB_LIBRARY_API crocksdb_sstfilewriter_t*

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -661,9 +661,12 @@ extern "C" {
 
     // SstFileWriter
     pub fn crocksdb_sstfilewriter_create(env: *mut EnvOptions,
-                                         io_options: *const DBOptions,
-                                         cf: *mut DBCFHandle)
+                                         io_options: *const DBOptions)
                                          -> *mut SstFileWriter;
+    pub fn crocksdb_sstfilewriter_create_cf(env: *mut EnvOptions,
+                                            io_options: *const DBOptions,
+                                            cf: *mut DBCFHandle)
+                                            -> *mut SstFileWriter;
     pub fn crocksdb_sstfilewriter_create_with_comparator(env: *mut EnvOptions,
                                                          io_options: *const DBOptions,
                                                          comparator: *const DBComparator,

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -1343,12 +1343,20 @@ pub struct SstFileWriter {
 unsafe impl Send for SstFileWriter {}
 
 impl SstFileWriter {
-    pub fn new(env_opt: &EnvOptions, opt: &Options, cf: &CFHandle) -> SstFileWriter {
+    pub fn new(env_opt: &EnvOptions, opt: &Options) -> SstFileWriter {
         unsafe {
             SstFileWriter {
-                inner: crocksdb_ffi::crocksdb_sstfilewriter_create(env_opt.inner,
-                                                                   opt.inner,
-                                                                   cf.inner),
+                inner: crocksdb_ffi::crocksdb_sstfilewriter_create(env_opt.inner, opt.inner),
+            }
+        }
+    }
+
+    pub fn new_cf(env_opt: &EnvOptions, opt: &Options, cf: &CFHandle) -> SstFileWriter {
+        unsafe {
+            SstFileWriter {
+                inner: crocksdb_ffi::crocksdb_sstfilewriter_create_cf(env_opt.inner,
+                                                                      opt.inner,
+                                                                      cf.inner),
             }
         }
     }
@@ -1802,7 +1810,8 @@ mod test {
         }
         db.flush_cf(cf_handle, true).unwrap();
 
-        let total_sst_files_size = db.get_property_int_cf(cf_handle, "rocksdb.total-sst-files-size").unwrap();
+        let total_sst_files_size = db.get_property_int_cf(cf_handle, "rocksdb.total-sst-files-size")
+            .unwrap();
         assert!(total_sst_files_size > 0);
     }
 }

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -800,9 +800,7 @@ impl Options {
     }
 
     pub fn get_block_cache_usage(&self) -> u64 {
-        unsafe {
-            crocksdb_ffi::crocksdb_options_get_block_cache_usage(self.inner) as u64
-        }
+        unsafe { crocksdb_ffi::crocksdb_options_get_block_cache_usage(self.inner) as u64 }
     }
 }
 


### PR DESCRIPTION
Hi,

This PR adds a constructor for `SstFileWriter`, which could be used without specified cf handle.

It's needed by https://github.com/pingcap/tikv/pull/1798

PTAL @zhangjinpeng1987 @siddontang @BusyJay 