### PR TITLE
add GetFilterBitsBuilder/GetFilterBitsReader for c bloom

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -81,6 +81,8 @@ using rocksdb::RateLimiter;
 using rocksdb::NewGenericRateLimiter;
 using rocksdb::HistogramData;
 using rocksdb::PinnableSlice;
+using rocksdb::FilterBitsBuilder;
+using rocksdb::FilterBitsReader;
 
 using std::shared_ptr;
 
@@ -2089,7 +2091,8 @@ void crocksdb_options_set_fifo_compaction_options(
   opt->rep.compaction_options_fifo = fifo->rep;
 }
 
-void crocksdb_options_set_compaction_priority(crocksdb_options_t *opt, unsigned char priority) {
+void crocksdb_options_set_compaction_priority(crocksdb_options_t *opt,
+                                              unsigned char priority) {
   opt->rep.compaction_pri = static_cast<rocksdb::CompactionPri>(priority);
 }
 
@@ -2309,6 +2312,13 @@ crocksdb_filterpolicy_t* crocksdb_filterpolicy_create_bloom_format(int bits_per_
     }
     bool KeyMayMatch(const Slice& key, const Slice& filter) const override {
       return rep_->KeyMayMatch(key, filter);
+    }
+    virtual FilterBitsBuilder *GetFilterBitsBuilder() const override {
+      return rep_->GetFilterBitsBuilder();
+    }
+    virtual FilterBitsReader *
+    GetFilterBitsReader(const Slice &contents) const override {
+      return rep_->GetFilterBitsReader(contents);
     }
     static void DoNothing(void*) { }
   };

--- a/librocksdb_sys/crocksdb/rocksdb/c.h
+++ b/librocksdb_sys/crocksdb/rocksdb/c.h
@@ -835,13 +835,13 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_ratelimiter(
     crocksdb_options_t* opt, crocksdb_ratelimiter_t* limiter);
 
 enum {
-    compaction_by_compensated_size = 0,
-    compaction_by_oldest_largestseq_first = 1,
-    compaction_by_oldest_smallest_seq_first = 2,
-    compaction_by_min_overlapping_ratio = 3,
+  compaction_by_compensated_size = 0,
+  compaction_by_oldest_largestseq_first = 1,
+  compaction_by_oldest_smallest_seq_first = 2,
+  compaction_by_min_overlapping_ratio = 3,
 };
-extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_compaction_priority(
-    crocksdb_options_t*, unsigned char);
+extern C_ROCKSDB_LIBRARY_API void
+crocksdb_options_set_compaction_priority(crocksdb_options_t *, unsigned char);
 
 /* RateLimiter */
 extern C_ROCKSDB_LIBRARY_API crocksdb_ratelimiter_t* crocksdb_ratelimiter_create(


### PR DESCRIPTION
If we don't implement `GetFilterBitsBuilder` interface for `FilterPolicy`, the default one which return null will effect the filter type, we except `FullFilter` but we get `BlockBasedFilter`.
https://github.com/facebook/rocksdb/blob/master/table/block_based_table_builder.cc#L74