### PR TITLE
Revert "explicit fail when rocksdb version is too low"

### DIFF
--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -18,4 +18,3 @@ sse = []
 
 [build-dependencies]
 gcc = "0.3"
-pkg-config = "0.3.8"

--- a/librocksdb_sys/build.rs
+++ b/librocksdb_sys/build.rs
@@ -1,5 +1,5 @@
+
 extern crate gcc;
-extern crate pkg_config;
 
 use std::{env, fs, str};
 use std::path::PathBuf;
@@ -13,15 +13,7 @@ macro_rules! t {
 }
 
 fn main() {
-    const ROCKSDB_VERSION: &'static str = "5.4";
-
     if !cfg!(feature = "static-link") {
-        match pkg_config::Config::new().atleast_version(ROCKSDB_VERSION).probe("rocksdb") {
-            Ok(_) => (),
-            Err(_) => {
-                panic!("failed to find rocksdb >= {} by pkg-config", ROCKSDB_VERSION);
-            }
-        }
         gcc::Config::new()
         .cpp(true)
         .file("crocksdb/c.cc")


### PR DESCRIPTION
Reverts pingcap/rust-rocksdb#68

compile fails under macOS.

the recommended way of compiling (dynamic linked) is:

``LIBRARY_PATH=/usr/local/lib CXXFLAGS=-I/usr/local/include cargo build``