### PR TITLE
rocksdb: implement Clone trait for Options

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -112,7 +112,10 @@ struct crocksdb_readoptions_t {
    Slice upper_bound; // stack variable to set pointer to in ReadOptions
 };
 struct crocksdb_writeoptions_t    { WriteOptions      rep; };
-struct crocksdb_options_t         { Options           rep; };
+struct crocksdb_options_t         { 
+  crocksdb_options_t() = default;
+  crocksdb_options_t(const crocksdb_options_t& other): rep(other.rep) {}
+  Options           rep; };
 struct crocksdb_compactoptions_t {
   CompactRangeOptions rep;
 };
@@ -1590,7 +1593,11 @@ crocksdb_options_t* crocksdb_options_create() {
   return new crocksdb_options_t;
 }
 
-void crocksdb_options_destroy(crocksdb_options_t* options) {
+crocksdb_options_t* crocksdb_options_copy(crocksdb_options_t *other) {
+  return new crocksdb_options_t(*other);
+}
+
+void crocksdb_options_destroy(const crocksdb_options_t* options) {
   delete options;
 }
 

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -112,10 +112,7 @@ struct crocksdb_readoptions_t {
    Slice upper_bound; // stack variable to set pointer to in ReadOptions
 };
 struct crocksdb_writeoptions_t    { WriteOptions      rep; };
-struct crocksdb_options_t         { 
-  crocksdb_options_t() = default;
-  crocksdb_options_t(const crocksdb_options_t& other): rep(other.rep) {}
-  Options           rep; };
+struct crocksdb_options_t         { Options           rep; };
 struct crocksdb_compactoptions_t {
   CompactRangeOptions rep;
 };
@@ -1594,7 +1591,7 @@ crocksdb_options_t* crocksdb_options_create() {
 }
 
 crocksdb_options_t* crocksdb_options_copy(const crocksdb_options_t *other) {
-  return new crocksdb_options_t(*other);
+  return new crocksdb_options_t { Options(other->rep) };
 }
 
 void crocksdb_options_destroy(crocksdb_options_t* options) {

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -1593,11 +1593,11 @@ crocksdb_options_t* crocksdb_options_create() {
   return new crocksdb_options_t;
 }
 
-crocksdb_options_t* crocksdb_options_copy(crocksdb_options_t *other) {
+crocksdb_options_t* crocksdb_options_copy(const crocksdb_options_t *other) {
   return new crocksdb_options_t(*other);
 }
 
-void crocksdb_options_destroy(const crocksdb_options_t* options) {
+void crocksdb_options_destroy(crocksdb_options_t* options) {
   delete options;
 }
 

--- a/librocksdb_sys/crocksdb/rocksdb/c.h
+++ b/librocksdb_sys/crocksdb/rocksdb/c.h
@@ -602,8 +602,8 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_cuckoo_table_factory(
 /* Options */
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_options_t* crocksdb_options_create();
-extern C_ROCKSDB_LIBRARY_API crocksdb_options_t* crocksdb_options_copy(crocksdb_options_t*);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_options_destroy(const crocksdb_options_t*);
+extern C_ROCKSDB_LIBRARY_API crocksdb_options_t* crocksdb_options_copy(const crocksdb_options_t*);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_options_destroy(crocksdb_options_t*);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_increase_parallelism(
     crocksdb_options_t* opt, int total_threads);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_optimize_for_point_lookup(

--- a/librocksdb_sys/crocksdb/rocksdb/c.h
+++ b/librocksdb_sys/crocksdb/rocksdb/c.h
@@ -602,7 +602,8 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_cuckoo_table_factory(
 /* Options */
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_options_t* crocksdb_options_create();
-extern C_ROCKSDB_LIBRARY_API void crocksdb_options_destroy(crocksdb_options_t*);
+extern C_ROCKSDB_LIBRARY_API crocksdb_options_t* crocksdb_options_copy(crocksdb_options_t*);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_options_destroy(const crocksdb_options_t*);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_increase_parallelism(
     crocksdb_options_t* opt, int total_threads);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_optimize_for_point_lookup(

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -237,6 +237,7 @@ macro_rules! ffi_try {
 extern "C" {
     pub fn crocksdb_get_options_cf(db: *mut DBInstance, cf: *mut DBCFHandle) -> *mut DBOptions;
     pub fn crocksdb_options_create() -> *mut DBOptions;
+    pub fn crocksdb_options_copy(opts: *const DBOptions) -> *mut DBOptions;
     pub fn crocksdb_options_destroy(opts: *mut DBOptions);
     pub fn crocksdb_cache_create_lru(capacity: size_t) -> *mut DBCache;
     pub fn crocksdb_cache_destroy(cache: *mut DBCache);

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -320,8 +320,8 @@ impl Default for Options {
 }
 
 impl Clone for Options {
-    // Only copy DBOptions.
     fn clone(&self) -> Self {
+        assert!(self.filter.is_none());
         unsafe {
             let opts = crocksdb_ffi::crocksdb_options_copy(self.inner);
             assert!(!opts.is_null());

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -319,6 +319,20 @@ impl Default for Options {
     }
 }
 
+impl Clone for Options {
+    // Only copy DBOptions.
+    fn clone(&self) -> Self {
+        unsafe {
+            let opts = crocksdb_ffi::crocksdb_options_copy(self.inner);
+            assert!(!opts.is_null());
+            Options {
+                inner: opts,
+                filter: None,
+            }
+        }
+    }
+}
+
 impl Options {
     pub fn new() -> Options {
         Options::default()

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -376,3 +376,11 @@ fn test_get_compression_per_level() {
     let v2 = opts2.get_compression_per_level();
     assert_eq!(v2.len(), 0);
 }
+
+#[test]
+fn test_clone_options() {
+    let mut opts = Options::new();
+    opts.compression(DBCompressionType::DBSnappy);
+    let opts2 = opts.clone();
+    assert_eq!(opts.get_compression(), opts2.get_compression());
+}


### PR DESCRIPTION
@zhangjinpeng1987 PTAL
In our use cases we don't need to clone filter, and CompactionFilterHandle is quite complex.