### PR TITLE
build: disable jemalloc

### DIFF
--- a/librocksdb_sys/build.sh
+++ b/librocksdb_sys/build.sh
@@ -135,7 +135,7 @@ function compile_rocksdb() {
     cd rocksdb
     export EXTRA_CFLAGS="-fPIC -I${wd}/zlib-1.2.11 -I${wd}/bzip2-1.0.6 -I${wd}/snappy-1.1.1 -I${wd}/lz4-r131/lib -I${wd}/zstd-1.2.0/lib"
     export EXTRA_CXXFLAGS="-DZLIB -DBZIP2 -DSNAPPY -DLZ4 -DZSTD $EXTRA_CFLAGS"
-    make static_lib -j $con
+    DISABLE_JEMALLOC=1 make static_lib -j $con
     mv librocksdb.a ../
     cd ..
 }


### PR DESCRIPTION
Makefile will link to jemalloc automatically if it's installed on the system. But this may lead to unexpected build failure if installed jemalloc is outdated. Actually rustc will link to built-in jemalloc automatically, hence we can just skip it when building native library.