### PR TITLE
*: remove redundant DB prefix

### DIFF
--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -79,23 +79,23 @@ pub enum DBEntryType {
 #[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(C)]
 pub enum DBCompressionType {
-    DBNo = 0,
-    DBSnappy = 1,
-    DBZlib = 2,
-    DBBz2 = 3,
-    DBLz4 = 4,
-    DBLz4hc = 5,
+    No = 0,
+    Snappy = 1,
+    Zlib = 2,
+    Bz2 = 3,
+    Lz4 = 4,
+    Lz4hc = 5,
     // DBXpress = 6, not support currently.
-    DBZstd = 7,
-    DBZstdNotFinal = 0x40,
-    DBDisableCompression = 0xff,
+    Zstd = 7,
+    ZstdNotFinal = 0x40,
+    Disable = 0xff,
 }
 
 #[repr(C)]
 pub enum DBCompactionStyle {
-    DBLevel = 0,
-    DBUniversal = 1,
-    DBFifo = 2,
+    Level = 0,
+    Universal = 1,
+    Fifo = 2,
 }
 
 #[repr(C)]
@@ -177,21 +177,21 @@ pub enum DBStatisticsTickerType {
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub enum DBStatisticsHistogramType {
-    DbGetMicros = 0,
-    DbWriteMicros = 1,
-    DbSeekMicros = 19,
+    GetMicros = 0,
+    WriteMicros = 1,
+    SeekMicros = 19,
 }
 
 #[derive(Copy, Clone)]
 #[repr(C)]
 pub enum DBInfoLogLevel {
-    DBDebug = 0,
-    DBInfo = 1,
-    DBWarn = 2,
-    DBError = 3,
-    DBFatal = 4,
-    DBHeader = 5,
-    DBNumInfoLog = 6,
+    Debug = 0,
+    Info = 1,
+    Warn = 2,
+    Error = 3,
+    Fatal = 4,
+    Header = 5,
+    NumInfoLog = 6,
 }
 
 #[derive(Copy, Clone, Eq, PartialEq)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,7 +116,7 @@ fn custom_merge() {
 #[cfg(test)]
 mod tests {
     use rocksdb::{BlockBasedOptions, DB, DBCompressionType, Options};
-    use rocksdb::DBCompactionStyle::DBUniversal;
+    use rocksdb::DBCompactionStyle;
     use rocksdb::DBRecoveryMode;
 
     #[allow(dead_code)]
@@ -124,13 +124,13 @@ mod tests {
                                      mut opts: Options,
                                      blockopts: &mut BlockBasedOptions)
                                      -> DB {
-        let per_level_compression: [DBCompressionType; 7] = [DBCompressionType::DBNo,
-                                                             DBCompressionType::DBNo,
-                                                             DBCompressionType::DBNo,
-                                                             DBCompressionType::DBLz4,
-                                                             DBCompressionType::DBLz4,
-                                                             DBCompressionType::DBLz4,
-                                                             DBCompressionType::DBLz4];
+        let per_level_compression: [DBCompressionType; 7] = [DBCompressionType::No,
+                                                             DBCompressionType::No,
+                                                             DBCompressionType::No,
+                                                             DBCompressionType::Lz4,
+                                                             DBCompressionType::Lz4,
+                                                             DBCompressionType::Lz4,
+                                                             DBCompressionType::Lz4];
 
         opts.create_if_missing(true);
         opts.set_max_open_files(10000);
@@ -145,7 +145,7 @@ mod tests {
         opts.set_level_zero_file_num_compaction_trigger(4);
         opts.set_level_zero_stop_writes_trigger(2000);
         opts.set_level_zero_slowdown_writes_trigger(0);
-        opts.set_compaction_style(DBUniversal);
+        opts.set_compaction_style(DBCompactionStyle::Universal);
         opts.set_max_background_compactions(4);
         opts.set_max_background_flushes(4);
         opts.set_report_bg_io_stats(true);

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -66,7 +66,7 @@ fn test_enable_statistics() {
     opts.enable_statistics();
     opts.set_stats_dump_period_sec(60);
     assert!(opts.get_statistics().is_some());
-    assert!(opts.get_statistics_histogram_string(HistogramType::DbSeekMicros)
+    assert!(opts.get_statistics_histogram_string(HistogramType::SeekMicros)
         .is_some());
     assert_eq!(opts.get_statistics_ticker_count(TickerType::BlockCacheMiss),
                0);
@@ -165,7 +165,7 @@ fn test_create_info_log() {
     let path = TempDir::new("_rust_rocksdb_test_create_info_log_opt").expect("");
     let mut opts = Options::new();
     opts.create_if_missing(true);
-    opts.set_info_log_level(InfoLogLevel::DBDebug);
+    opts.set_info_log_level(InfoLogLevel::Debug);
     opts.set_log_file_time_to_roll(1);
 
     let info_dir = TempDir::new("_rust_rocksdb_test_info_log_dir").expect("");
@@ -370,19 +370,19 @@ fn test_enable_pipelined_write() {
 fn test_get_compression() {
     let mut opts = Options::new();
     opts.create_if_missing(true);
-    opts.compression(DBCompressionType::DBSnappy);
-    assert_eq!(opts.get_compression(), DBCompressionType::DBSnappy);
+    opts.compression(DBCompressionType::Snappy);
+    assert_eq!(opts.get_compression(), DBCompressionType::Snappy);
 }
 
 #[test]
 fn test_get_compression_per_level() {
     let mut opts = Options::new();
-    let compressions = &[DBCompressionType::DBNo, DBCompressionType::DBSnappy];
+    let compressions = &[DBCompressionType::No, DBCompressionType::Snappy];
     opts.compression_per_level(compressions);
     let v = opts.get_compression_per_level();
     assert_eq!(v.len(), 2);
-    assert_eq!(v[0], DBCompressionType::DBNo);
-    assert_eq!(v[1], DBCompressionType::DBSnappy);
+    assert_eq!(v[0], DBCompressionType::No);
+    assert_eq!(v[1], DBCompressionType::Snappy);
     let mut opts2 = Options::new();
     let empty: &[DBCompressionType] = &[];
     opts2.compression_per_level(empty);
@@ -395,14 +395,14 @@ fn test_bottommost_compression() {
     let path = TempDir::new("_rust_rocksdb_bottommost_compression").expect("");
     let mut opts = Options::new();
     opts.create_if_missing(true);
-    opts.bottommost_compression(DBCompressionType::DBNo);
+    opts.bottommost_compression(DBCompressionType::No);
     DB::open(opts, path.path().to_str().unwrap()).unwrap();
 }
 
 #[test]
 fn test_clone_options() {
     let mut opts = Options::new();
-    opts.compression(DBCompressionType::DBSnappy);
+    opts.compression(DBCompressionType::Snappy);
     let opts2 = opts.clone();
     assert_eq!(opts.get_compression(), opts2.get_compression());
 }

--- a/tests/test_statistics.rs
+++ b/tests/test_statistics.rs
@@ -35,8 +35,8 @@ fn test_db_statistics() {
     assert!(db.get_statistics_ticker_count(TickerType::BlockCacheHit) > 0);
     assert!(db.get_and_reset_statistics_ticker_count(TickerType::BlockCacheHit) > 0);
     assert_eq!(db.get_statistics_ticker_count(TickerType::BlockCacheHit), 0);
-    assert!(db.get_statistics_histogram_string(HistogramType::DbGetMicros)
+    assert!(db.get_statistics_histogram_string(HistogramType::GetMicros)
         .is_some());
-    assert!(db.get_statistics_histogram(HistogramType::DbGetMicros)
+    assert!(db.get_statistics_histogram(HistogramType::GetMicros)
         .is_some());
 }


### PR DESCRIPTION
So it will be more easy to unify configuration later.