### PR TITLE
support max_background_jobs

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -2111,17 +2111,8 @@ void crocksdb_options_set_max_write_buffer_number_to_maintain(
   opt->rep.max_write_buffer_number_to_maintain = n;
 }
 
-void crocksdb_options_set_max_background_compactions(crocksdb_options_t* opt, int n) {
-  opt->rep.max_background_compactions = n;
-}
-
-void crocksdb_options_set_base_background_compactions(crocksdb_options_t* opt,
-                                                     int n) {
-  opt->rep.base_background_compactions = n;
-}
-
-void crocksdb_options_set_max_background_flushes(crocksdb_options_t* opt, int n) {
-  opt->rep.max_background_flushes = n;
+void crocksdb_options_set_max_background_jobs(crocksdb_options_t* opt, int n) {
+  opt->rep.max_background_jobs = n;
 }
 
 void crocksdb_options_set_max_log_file_size(crocksdb_options_t* opt, size_t v) {

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -788,11 +788,7 @@ crocksdb_options_set_min_write_buffer_number_to_merge(crocksdb_options_t*, int);
 extern C_ROCKSDB_LIBRARY_API void
 crocksdb_options_set_max_write_buffer_number_to_maintain(crocksdb_options_t *,
                                                          int);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_max_background_compactions(
-    crocksdb_options_t*, int);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_base_background_compactions(
-    crocksdb_options_t*, int);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_max_background_flushes(
+extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_max_background_jobs(
     crocksdb_options_t*, int);
 extern C_ROCKSDB_LIBRARY_API void
 crocksdb_options_set_max_log_file_size(crocksdb_options_t *, size_t);

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -327,12 +327,7 @@ extern "C" {
     pub fn crocksdb_options_get_compression_per_level(options: *mut Options,
                                                       level_values: *mut DBCompressionType);
     pub fn crocksdb_set_bottommost_compression(options: *mut Options, c: DBCompressionType);
-    pub fn crocksdb_options_set_base_background_compactions(optinos: *mut Options,
-                                                            base_bg_compactions: c_int);
-    pub fn crocksdb_options_set_max_background_compactions(options: *mut Options,
-                                                           max_bg_compactions: c_int);
-    pub fn crocksdb_options_set_max_background_flushes(options: *mut Options,
-                                                       max_bg_flushes: c_int);
+    pub fn crocksdb_options_set_max_background_jobs(options: *mut Options, max_bg_jobs: c_int);
     pub fn crocksdb_options_set_disable_auto_compactions(options: *mut Options, v: c_int);
     pub fn crocksdb_options_set_report_bg_io_stats(options: *mut Options, v: c_int);
     pub fn crocksdb_options_set_compaction_readahead_size(options: *mut Options, v: size_t);

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,8 +147,7 @@ mod tests {
         cf_opts.set_level_zero_stop_writes_trigger(2000);
         cf_opts.set_level_zero_slowdown_writes_trigger(0);
         cf_opts.set_compaction_style(DBCompactionStyle::Universal);
-        opts.set_max_background_compactions(4);
-        opts.set_max_background_flushes(4);
+        opts.set_max_background_jobs(4);
         cf_opts.set_report_bg_io_stats(true);
         opts.set_wal_recovery_mode(DBRecoveryMode::PointInTime);
         opts.enable_statistics();

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -407,9 +407,9 @@ impl DBOptions {
         }
     }
 
-    pub fn set_max_background_flushes(&mut self, n: c_int) {
+    pub fn set_max_background_jobs(&mut self, n: c_int) {
         unsafe {
-            crocksdb_ffi::crocksdb_options_set_max_background_flushes(self.inner, n);
+            crocksdb_ffi::crocksdb_options_set_max_background_jobs(self.inner, n);
         }
     }
 
@@ -422,19 +422,6 @@ impl DBOptions {
     pub fn set_wal_bytes_per_sync(&mut self, n: u64) {
         unsafe {
             crocksdb_ffi::crocksdb_options_set_wal_bytes_per_sync(self.inner, n);
-        }
-    }
-
-
-    pub fn set_base_background_compactions(&mut self, n: c_int) {
-        unsafe {
-            crocksdb_ffi::crocksdb_options_set_base_background_compactions(self.inner, n);
-        }
-    }
-
-    pub fn set_max_background_compactions(&mut self, n: c_int) {
-        unsafe {
-            crocksdb_ffi::crocksdb_options_set_max_background_compactions(self.inner, n);
         }
     }
 

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -360,11 +360,11 @@ fn test_writable_file_max_buffer_size() {
 }
 
 #[test]
-fn test_set_base_background_compactions() {
-    let path = TempDir::new("_rust_rocksdb_base_background_compactions").expect("");
+fn test_set_max_background_jobs() {
+    let path = TempDir::new("_rust_rocksdb_max_background_jobs").expect("");
     let mut opts = DBOptions::new();
     opts.create_if_missing(true);
-    opts.set_base_background_compactions(4);
+    opts.set_max_background_jobs(4);
     DB::open(opts, path.path().to_str().unwrap()).unwrap();
 }
 


### PR DESCRIPTION
Use max_background_jobs instead of max_background_flushes, max_background_compactions and base_background_compactions.