### PR TITLE
[DNM] tests: add bloom filter in sst

### DIFF
--- a/tests/test_delete_range.rs
+++ b/tests/test_delete_range.rs
@@ -675,7 +675,9 @@ fn test_prefix_bloom_delete_after_ingest() {
     let gen_path = TempDir::new("_rust_rocksdb_case_prefix_bloom_1_ingest_sst_gen").expect("");
     let test_sstfile = gen_path.path().join("test_sst_file");
     let test_sstfile_str = test_sstfile.to_str().unwrap();
-    let ingest_opt = IngestExternalFileOptions::new();
+    let mut ingest_opt = IngestExternalFileOptions::new();
+    ingest_opt.allow_global_seqno(true);
+    ingest_opt.allow_blocking_flush(true);
 
     let default_options = db.get_options();
     gen_sst_from_db(default_options,
@@ -702,7 +704,9 @@ fn test_prefix_bloom_delete_after_ingest() {
 
     db.delete_cf(handle, b"keyb22222").unwrap();
 
-    let mut iter = db.iter();
+    let mut ro = ReadOptions::new();
+    ro.set_total_order_seek(true);
+    let mut iter = db.iter_opt(ro);
     iter.seek(SeekKey::Key(b"keya11112"));
     assert!(iter.valid());
     assert_ne!(iter.key(), b"keyb22222");

--- a/tests/test_delete_range.rs
+++ b/tests/test_delete_range.rs
@@ -531,32 +531,27 @@ pub fn get_cf_handle<'a>(db: &'a DB, cf: &str) -> Result<&'a CFHandle, String> {
         .ok_or_else(|| format!("cf {} not found.", cf))
 }
 
-fn create_cf_db(db_path: &str, cf_name: &str) -> DB {
-    let path = TempDir::new(db_path).expect("");
-    let path_str = path.path().to_str().unwrap();
-
-//    let mut bbto = BlockBasedOptions::new();
-//    bbto.set_bloom_filter(10, false);
-//    bbto.set_whole_key_filtering(false);
-    let mut opts = DBOptions::new();
-    let mut cf_opts = ColumnFamilyOptions::new();
-    opts.create_if_missing(true);
-//    cf_opts.set_block_based_table_factory(&bbto);
-
-    // Prefix extractor(trim the timestamp at tail) for write cf.
-    cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
-                              Box::new(FixedSuffixSliceTransform::new(3)))
-        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
-    // Create prefix bloom filter for memtable.
-//    cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
-    let db = DB::open_cf(opts, path_str, vec![cf_name], vec![cf_opts]).unwrap();
-    db
-}
-
 #[test]
 fn test_delete_range_prefix_bloom_case_1() {
     let cf = "default";
-    let db = create_cf_db("_rust_rocksdb_test_delete_range_prefix_bloom_case_1", cf);
+    let path = TempDir::new("_rust_rocksdb_test_delete_range_prefix_bloom_case_1").expect("");
+    let path_str = path.path().to_str().unwrap();
+
+    let mut bbto = BlockBasedOptions::new();
+    bbto.set_bloom_filter(10, false);
+    bbto.set_whole_key_filtering(false);
+    let mut opts = DBOptions::new();
+    let mut cf_opts = ColumnFamilyOptions::new();
+    opts.create_if_missing(true);
+    cf_opts.set_block_based_table_factory(&bbto);
+
+    // Prefix extractor(trim the timestamp at tail) for write cf.
+    cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
+                                 Box::new(FixedSuffixSliceTransform::new(3)))
+        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+    // Create prefix bloom filter for memtable.
+    cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
+    let db = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
 
     let samples_a = vec![(b"keya11111", b"value1"),
                          (b"keyb22222", b"value2"),
@@ -604,7 +599,24 @@ fn test_delete_range_prefix_bloom_case_1() {
 #[test]
 fn test_prefix_bloom_delete_after_ingest() {
     let cf = "default";
-    let db = create_cf_db("_rust_rocksdb_test_delete_range_prefix_bloom_case_1", cf);
+    let path = TempDir::new("_rust_rocksdb_test_prefix_bloom_after_ingest").expect("");
+    let path_str = path.path().to_str().unwrap();
+
+    let mut bbto = BlockBasedOptions::new();
+    bbto.set_bloom_filter(10, false);
+    bbto.set_whole_key_filtering(false);
+    let mut opts = DBOptions::new();
+    let mut cf_opts = ColumnFamilyOptions::new();
+    opts.create_if_missing(true);
+    cf_opts.set_block_based_table_factory(&bbto);
+
+    // Prefix extractor(trim the timestamp at tail) for write cf.
+    cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
+                                 Box::new(FixedSuffixSliceTransform::new(3)))
+        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+    // Create prefix bloom filter for memtable.
+    cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
+    let db = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
 
     let samples_a = vec![(b"keya11111", b"value1"),
                          (b"keyb22222", b"value2"),
@@ -659,7 +671,24 @@ fn test_prefix_bloom_delete_after_ingest() {
 #[test]
 fn test_delete_range_prefix_bloom_case_2() {
     let cf = "default";
-    let db = create_cf_db("_rust_rocksdb_test_delete_range_prefix_bloom_case_2", cf);
+    let path = TempDir::new("_rust_rocksdb_test_delete_range_prefix_bloom_case_2").expect("");
+    let path_str = path.path().to_str().unwrap();
+
+    let mut bbto = BlockBasedOptions::new();
+    bbto.set_bloom_filter(10, false);
+    bbto.set_whole_key_filtering(false);
+    let mut opts = DBOptions::new();
+    let mut cf_opts = ColumnFamilyOptions::new();
+    opts.create_if_missing(true);
+    cf_opts.set_block_based_table_factory(&bbto);
+
+    // Prefix extractor(trim the timestamp at tail) for write cf.
+    cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
+                                 Box::new(FixedSuffixSliceTransform::new(3)))
+        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+    // Create prefix bloom filter for memtable.
+    cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
+    let db = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
     let handle = get_cf_handle(&db, cf).unwrap();
 
     let samples_a = vec![(b"keya11111", b"value1"),
@@ -691,7 +720,24 @@ fn test_delete_range_prefix_bloom_case_2() {
                (b"keyc33333", None),
                (b"keyd44444", None)]);
 
-    let db2 = create_cf_db("_rust_rocksdb_test_delete_range_prefix_bloom_case_2_2", cf);
+    let path2 = TempDir::new("_rust_rocksdb_test_delete_range_prefix_bloom_case_2_2").expect("");
+    let path_str2 = path2.path().to_str().unwrap();
+
+    let mut bbto2 = BlockBasedOptions::new();
+    bbto2.set_bloom_filter(10, false);
+    bbto2.set_whole_key_filtering(false);
+    let mut opts2 = DBOptions::new();
+    let mut cf_opts2 = ColumnFamilyOptions::new();
+    opts2.create_if_missing(true);
+    cf_opts2.set_block_based_table_factory(&bbto2);
+
+    // Prefix extractor(trim the timestamp at tail) for write cf.
+    cf_opts2.set_prefix_extractor("FixedSuffixSliceTransform",
+                                 Box::new(FixedSuffixSliceTransform::new(3)))
+        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+    // Create prefix bloom filter for memtable.
+    cf_opts2.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
+    let db2 = DB::open_cf(opts2, path_str2, vec![cf], vec![cf_opts2]).unwrap();
     let handle2 = get_cf_handle(&db2, cf).unwrap();
 
     db2.ingest_external_file_cf(handle2, &ingest_opt, &[test_sstfile_str])
@@ -710,8 +756,24 @@ fn test_delete_range_prefix_bloom_case_2() {
 #[test]
 fn test_delete_range_prefix_bloom_case_3() {
     let cf = "default";
-    let db = create_cf_db("_rust_rocksdb_test_delete_range_prefix_bloom_case_3", cf);
-    let handle = get_cf_handle(&db, cf).unwrap();
+    let path = TempDir::new("_rust_rocksdb_test_delete_range_prefix_bloom_case_3").expect("");
+    let path_str = path.path().to_str().unwrap();
+
+    let mut bbto = BlockBasedOptions::new();
+    bbto.set_bloom_filter(10, false);
+    bbto.set_whole_key_filtering(false);
+    let mut opts = DBOptions::new();
+    let mut cf_opts = ColumnFamilyOptions::new();
+    opts.create_if_missing(true);
+    cf_opts.set_block_based_table_factory(&bbto);
+
+    // Prefix extractor(trim the timestamp at tail) for write cf.
+    cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
+                                 Box::new(FixedSuffixSliceTransform::new(3)))
+        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+    // Create prefix bloom filter for memtable.
+    cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
+    let db = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();let handle = get_cf_handle(&db, cf).unwrap();
     let samples_a = vec![(b"keya11111", b"value1"),
                          (b"keyb22222", b"value2"),
                          (b"keyc33333", b"value3"),
@@ -733,7 +795,24 @@ fn test_delete_range_prefix_bloom_case_3() {
                (b"keyd44444", Some(b"value4")),
                (b"keye55555", Some(b"value5"))]);
 
-    let db2 = create_cf_db("_rust_rocksdb_test_delete_range_prefix_bloom_case_3_2", cf);
+    let path2 = TempDir::new("_rust_rocksdb_test_delete_range_prefix_bloom_case_3_2").expect("");
+    let path_str2 = path2.path().to_str().unwrap();
+
+    let mut bbto2 = BlockBasedOptions::new();
+    bbto2.set_bloom_filter(10, false);
+    bbto2.set_whole_key_filtering(false);
+    let mut opts2 = DBOptions::new();
+    let mut cf_opts2 = ColumnFamilyOptions::new();
+    opts2.create_if_missing(true);
+    cf_opts2.set_block_based_table_factory(&bbto2);
+
+    // Prefix extractor(trim the timestamp at tail) for write cf.
+    cf_opts2.set_prefix_extractor("FixedSuffixSliceTransform",
+                                  Box::new(FixedSuffixSliceTransform::new(3)))
+        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+    // Create prefix bloom filter for memtable.
+    cf_opts2.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
+    let db2 = DB::open_cf(opts2, path_str2, vec![cf], vec![cf_opts2]).unwrap();
     let handle2 = get_cf_handle(&db2, cf).unwrap();
     let samples_b = vec![(b"keyb22222", b"value2"), (b"keyc33333", b"value3")];
     for (k, v) in samples_b {
@@ -766,7 +845,24 @@ fn test_delete_range_prefix_bloom_case_3() {
 #[test]
 fn test_delete_range_prefix_bloom_case_4() {
     let cf = "default";
-    let db = create_cf_db("_rust_rocksdb_test_delete_range_prefix_bloom_case_4", cf);
+    let path = TempDir::new("_rust_rocksdb_test_delete_range_prefix_bloom_case_4").expect("");
+    let path_str = path.path().to_str().unwrap();
+
+    let mut bbto = BlockBasedOptions::new();
+    bbto.set_bloom_filter(10, false);
+    bbto.set_whole_key_filtering(false);
+    let mut opts = DBOptions::new();
+    let mut cf_opts = ColumnFamilyOptions::new();
+    opts.create_if_missing(true);
+    cf_opts.set_block_based_table_factory(&bbto);
+
+    // Prefix extractor(trim the timestamp at tail) for write cf.
+    cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
+                                 Box::new(FixedSuffixSliceTransform::new(3)))
+        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+    // Create prefix bloom filter for memtable.
+    cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
+    let db = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
     let handle = get_cf_handle(&db, cf).unwrap();
     let samples_a = vec![(b"keya11111", b"value1"),
                          (b"keyb22222", b"value2"),
@@ -789,7 +885,24 @@ fn test_delete_range_prefix_bloom_case_4() {
                (b"keyd44444", None),
                (b"keye55555", None)]);
 
-    let db2 = create_cf_db("_rust_rocksdb_test_delete_range_prefix_bloom_case_4_2", cf);
+    let path2 = TempDir::new("_rust_rocksdb_test_delete_range_prefix_bloom_case_4_2").expect("");
+    let path_str2 = path2.path().to_str().unwrap();
+
+    let mut bbto2 = BlockBasedOptions::new();
+    bbto2.set_bloom_filter(10, false);
+    bbto2.set_whole_key_filtering(false);
+    let mut opts2 = DBOptions::new();
+    let mut cf_opts2 = ColumnFamilyOptions::new();
+    opts2.create_if_missing(true);
+    cf_opts2.set_block_based_table_factory(&bbto2);
+
+    // Prefix extractor(trim the timestamp at tail) for write cf.
+    cf_opts2.set_prefix_extractor("FixedSuffixSliceTransform",
+                                  Box::new(FixedSuffixSliceTransform::new(3)))
+        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+    // Create prefix bloom filter for memtable.
+    cf_opts2.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
+    let db2 = DB::open_cf(opts2, path_str2, vec![cf], vec![cf_opts2]).unwrap();
     let handle2 = get_cf_handle(&db2, cf).unwrap();
 
 
@@ -825,7 +938,24 @@ fn test_delete_range_prefix_bloom_case_4() {
 #[test]
 fn test_delete_range_prefix_bloom_case_5() {
     let cf = "default";
-    let db = create_cf_db("_rust_rocksdb_test_delete_range_prefix_bloom_case_5", cf);
+    let path = TempDir::new("_rust_rocksdb_test_delete_range_prefix_bloom_case_5").expect("");
+    let path_str = path.path().to_str().unwrap();
+
+    let mut bbto = BlockBasedOptions::new();
+    bbto.set_bloom_filter(10, false);
+    bbto.set_whole_key_filtering(false);
+    let mut opts = DBOptions::new();
+    let mut cf_opts = ColumnFamilyOptions::new();
+    opts.create_if_missing(true);
+    cf_opts.set_block_based_table_factory(&bbto);
+
+    // Prefix extractor(trim the timestamp at tail) for write cf.
+    cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
+                                 Box::new(FixedSuffixSliceTransform::new(3)))
+        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+    // Create prefix bloom filter for memtable.
+    cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
+    let db = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
     let handle = get_cf_handle(&db, cf).unwrap();
     let samples_a = vec![(b"keya11111", b"value1"),
                          (b"keyb22222", b"value2"),
@@ -847,7 +977,24 @@ fn test_delete_range_prefix_bloom_case_5() {
                (b"keyd44444", None),
                (b"keye55555", None)]);
 
-    let db2 = create_cf_db("_rust_rocksdb_test_delete_range_prefix_bloom_case_5_2", cf);
+    let path2 = TempDir::new("_rust_rocksdb_test_delete_range_prefix_bloom_case_5_2").expect("");
+    let path_str2 = path2.path().to_str().unwrap();
+
+    let mut bbto2 = BlockBasedOptions::new();
+    bbto2.set_bloom_filter(10, false);
+    bbto2.set_whole_key_filtering(false);
+    let mut opts2 = DBOptions::new();
+    let mut cf_opts2 = ColumnFamilyOptions::new();
+    opts2.create_if_missing(true);
+    cf_opts2.set_block_based_table_factory(&bbto2);
+
+    // Prefix extractor(trim the timestamp at tail) for write cf.
+    cf_opts2.set_prefix_extractor("FixedSuffixSliceTransform",
+                                  Box::new(FixedSuffixSliceTransform::new(3)))
+        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+    // Create prefix bloom filter for memtable.
+    cf_opts2.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
+    let db2 = DB::open_cf(opts2, path_str2, vec![cf], vec![cf_opts2]).unwrap();
     let handle2 = get_cf_handle(&db2, cf).unwrap();
 
     let samples_b = vec![(b"keyd44444", b"value4"), (b"keye55555", b"value5")];
@@ -878,7 +1025,24 @@ fn test_delete_range_prefix_bloom_case_5() {
 #[test]
 fn test_delete_range_prefix_bloom_case_6() {
     let cf = "default";
-    let db = create_cf_db("_rust_rocksdb_test_delete_range_prefix_bloom_case_6", cf);
+    let path = TempDir::new("_rust_rocksdb_test_delete_range_prefix_bloom_case_6").expect("");
+    let path_str = path.path().to_str().unwrap();
+
+    let mut bbto = BlockBasedOptions::new();
+    bbto.set_bloom_filter(10, false);
+    bbto.set_whole_key_filtering(false);
+    let mut opts = DBOptions::new();
+    let mut cf_opts = ColumnFamilyOptions::new();
+    opts.create_if_missing(true);
+    cf_opts.set_block_based_table_factory(&bbto);
+
+    // Prefix extractor(trim the timestamp at tail) for write cf.
+    cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
+                                 Box::new(FixedSuffixSliceTransform::new(3)))
+        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+    // Create prefix bloom filter for memtable.
+    cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
+    let db = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
     let handle = get_cf_handle(&db, cf).unwrap();
     let samples_a = vec![(b"keya11111", b"value1"),
                          (b"keyb22222", b"value2"),
@@ -902,7 +1066,24 @@ fn test_delete_range_prefix_bloom_case_6() {
                (b"keyd44444", Some(b"value4")),
                (b"keye55555", Some(b"value5"))]);
 
-    let db2 = create_cf_db("_rust_rocksdb_test_delete_range_prefix_bloom_case_6_2", cf);
+    let path2 = TempDir::new("_rust_rocksdb_test_delete_range_prefix_bloom_case_6_2").expect("");
+    let path_str2 = path2.path().to_str().unwrap();
+
+    let mut bbto2 = BlockBasedOptions::new();
+    bbto2.set_bloom_filter(10, false);
+    bbto2.set_whole_key_filtering(false);
+    let mut opts2 = DBOptions::new();
+    let mut cf_opts2 = ColumnFamilyOptions::new();
+    opts2.create_if_missing(true);
+    cf_opts2.set_block_based_table_factory(&bbto2);
+
+    // Prefix extractor(trim the timestamp at tail) for write cf.
+    cf_opts2.set_prefix_extractor("FixedSuffixSliceTransform",
+                                  Box::new(FixedSuffixSliceTransform::new(3)))
+        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+    // Create prefix bloom filter for memtable.
+    cf_opts2.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
+    let db2 = DB::open_cf(opts2, path_str2, vec![cf], vec![cf_opts2]).unwrap();
     let handle2 = get_cf_handle(&db2, cf).unwrap();
 
     let samples_b =
@@ -954,7 +1135,7 @@ fn check_kv(db: &DB, cf: Option<&CFHandle>, data: &[(&[u8], Option<&[u8]>)]) {
 
 #[test]
 fn test_delete_range_prefix_bloom_compact_case() {
-    let path = TempDir::new("_rust_rocksdb_test_delete_range_prefix_bloom_case_6").expect("");
+    let path = TempDir::new("_rust_rocksdb_test_delete_range_prefix_bloom_case_compact").expect("");
     let path_str = path.path().to_str().unwrap();
     let mut opts = DBOptions::new();
     opts.create_if_missing(true);

--- a/tests/test_delete_range.rs
+++ b/tests/test_delete_range.rs
@@ -670,7 +670,6 @@ fn test_prefix_bloom_delete_after_ingest() {
         db.put_cf(handle, k, v).unwrap();
         assert_eq!(v, &*db.get(k).unwrap().unwrap());
     }
-    let before = gen_crc32_from_db(&db);
 
     let gen_path = TempDir::new("_rust_rocksdb_case_prefix_bloom_1_ingest_sst_gen").expect("");
     let test_sstfile = gen_path.path().join("test_sst_file");
@@ -710,9 +709,6 @@ fn test_prefix_bloom_delete_after_ingest() {
     iter.seek(SeekKey::Key(b"keya11112"));
     assert!(iter.valid());
     assert_ne!(iter.key(), b"keyb22222");
-
-    let after = gen_crc32_from_db(&db);
-    assert_eq!(before, after);
 }
 
 #[test]

--- a/tests/test_delete_range.rs
+++ b/tests/test_delete_range.rs
@@ -547,7 +547,7 @@ fn test_delete_range_prefix_bloom_case_1() {
 
     // Prefix extractor(trim the timestamp at tail) for write cf.
     cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
-                                 Box::new(FixedSuffixSliceTransform::new(3)))
+                                 Box::new(FixedSuffixSliceTransform::new(5)))
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
@@ -613,7 +613,7 @@ fn test_prefix_bloom_case_get_after_flush() {
 
     // Prefix extractor(trim the timestamp at tail) for write cf.
     cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
-                                 Box::new(FixedSuffixSliceTransform::new(3)))
+                                 Box::new(FixedSuffixSliceTransform::new(5)))
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
@@ -655,7 +655,7 @@ fn test_prefix_bloom_delete_after_ingest() {
 
     // Prefix extractor(trim the timestamp at tail) for write cf.
     cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
-                                 Box::new(FixedSuffixSliceTransform::new(3)))
+                                 Box::new(FixedSuffixSliceTransform::new(5)))
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
@@ -727,7 +727,7 @@ fn test_delete_range_prefix_bloom_case_2() {
 
     // Prefix extractor(trim the timestamp at tail) for write cf.
     cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
-                                 Box::new(FixedSuffixSliceTransform::new(3)))
+                                 Box::new(FixedSuffixSliceTransform::new(5)))
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
@@ -776,7 +776,7 @@ fn test_delete_range_prefix_bloom_case_2() {
 
     // Prefix extractor(trim the timestamp at tail) for write cf.
     cf_opts2.set_prefix_extractor("FixedSuffixSliceTransform",
-                                 Box::new(FixedSuffixSliceTransform::new(3)))
+                                 Box::new(FixedSuffixSliceTransform::new(5)))
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts2.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
@@ -812,7 +812,7 @@ fn test_delete_range_prefix_bloom_case_3() {
 
     // Prefix extractor(trim the timestamp at tail) for write cf.
     cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
-                                 Box::new(FixedSuffixSliceTransform::new(3)))
+                                 Box::new(FixedSuffixSliceTransform::new(5)))
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
@@ -851,7 +851,7 @@ fn test_delete_range_prefix_bloom_case_3() {
 
     // Prefix extractor(trim the timestamp at tail) for write cf.
     cf_opts2.set_prefix_extractor("FixedSuffixSliceTransform",
-                                  Box::new(FixedSuffixSliceTransform::new(3)))
+                                  Box::new(FixedSuffixSliceTransform::new(5)))
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts2.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
@@ -901,7 +901,7 @@ fn test_delete_range_prefix_bloom_case_4() {
 
     // Prefix extractor(trim the timestamp at tail) for write cf.
     cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
-                                 Box::new(FixedSuffixSliceTransform::new(3)))
+                                 Box::new(FixedSuffixSliceTransform::new(5)))
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
@@ -941,7 +941,7 @@ fn test_delete_range_prefix_bloom_case_4() {
 
     // Prefix extractor(trim the timestamp at tail) for write cf.
     cf_opts2.set_prefix_extractor("FixedSuffixSliceTransform",
-                                  Box::new(FixedSuffixSliceTransform::new(3)))
+                                  Box::new(FixedSuffixSliceTransform::new(5)))
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts2.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
@@ -994,7 +994,7 @@ fn test_delete_range_prefix_bloom_case_5() {
 
     // Prefix extractor(trim the timestamp at tail) for write cf.
     cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
-                                 Box::new(FixedSuffixSliceTransform::new(3)))
+                                 Box::new(FixedSuffixSliceTransform::new(5)))
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
@@ -1033,7 +1033,7 @@ fn test_delete_range_prefix_bloom_case_5() {
 
     // Prefix extractor(trim the timestamp at tail) for write cf.
     cf_opts2.set_prefix_extractor("FixedSuffixSliceTransform",
-                                  Box::new(FixedSuffixSliceTransform::new(3)))
+                                  Box::new(FixedSuffixSliceTransform::new(5)))
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts2.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
@@ -1081,7 +1081,7 @@ fn test_delete_range_prefix_bloom_case_6() {
 
     // Prefix extractor(trim the timestamp at tail) for write cf.
     cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
-                                 Box::new(FixedSuffixSliceTransform::new(3)))
+                                 Box::new(FixedSuffixSliceTransform::new(5)))
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
@@ -1097,7 +1097,7 @@ fn test_delete_range_prefix_bloom_case_6() {
         assert_eq!(v, &*db.get(k).unwrap().unwrap());
     }
 
-    let before = gen_crc32_from_db_in_range(&db, b"key4", b"key6");
+    let before = gen_crc32_from_db_in_range(&db, b"key44444", b"key66666");
 
     db.delete_range(b"keya11111", b"keyd44444").unwrap();
 
@@ -1122,7 +1122,7 @@ fn test_delete_range_prefix_bloom_case_6() {
 
     // Prefix extractor(trim the timestamp at tail) for write cf.
     cf_opts2.set_prefix_extractor("FixedSuffixSliceTransform",
-                                  Box::new(FixedSuffixSliceTransform::new(3)))
+                                  Box::new(FixedSuffixSliceTransform::new(5)))
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts2.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
@@ -1154,7 +1154,7 @@ fn test_delete_range_prefix_bloom_case_6() {
                (b"keyd44444", Some(b"value4")),
                (b"keye55555", Some(b"value5"))]);
 
-    let after = gen_crc32_from_db_in_range(&db, b"key4", b"key6");
+    let after = gen_crc32_from_db_in_range(&db, b"key44444", b"key66666");
     assert_eq!(before, after);
 }
 
@@ -1185,7 +1185,7 @@ fn test_delete_range_prefix_bloom_compact_case() {
     let mut cf_opts = ColumnFamilyOptions::new();
     // Prefix extractor(trim the timestamp at tail) for write cf.
     cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
-                              Box::new(FixedSuffixSliceTransform::new(3)))
+                              Box::new(FixedSuffixSliceTransform::new(5)))
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
@@ -1221,7 +1221,7 @@ fn test_delete_range_prefix_bloom_compact_case() {
     let mut cf_opts = ColumnFamilyOptions::new();
     // Prefix extractor(trim the timestamp at tail) for write cf.
     cf_opts.set_prefix_extractor("FixedSuffixSliceTransform",
-                              Box::new(FixedSuffixSliceTransform::new(3)))
+                              Box::new(FixedSuffixSliceTransform::new(5)))
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);


### PR DESCRIPTION
@siddontang @zhangjinpeng1987 PTAL
```
    test_delete_range::test_prefix_bloom_case_get_after_flush
    test_delete_range::test_prefix_bloom_delete_after_ingest
```
These two tests cannot pass now.
Signed-off-by: Cholerae Hu <huyingqian@pingcap.com>