### PR TITLE
Add type 'ColumnFamilyDescriptor' for 'open' related methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ portable = ["librocksdb_sys/portable"]
 sse = ["librocksdb_sys/sse"]
 
 [[test]]
-
 name = "test"
 path = "tests/test.rs"
 

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ endef
 # $(call format-code-in,file-or-dir)
 define format-code-in
 	$(if $(filter %.rs, $1),  \
-    $(call do-format-with-cmd, rustfmt, $1), \
-    cd $1 && $(call do-format-with-cmd, cargo fmt --))
+	$(call do-format-with-cmd, rustfmt, $1), \
+	cd $1 && $(call do-format-with-cmd, cargo fmt --))
 endef
 
 all: format build test
@@ -32,4 +32,4 @@ format:
 
 clean:
 	@cargo clean
-	@cd librocksdb_sys && cargo clean 
+	@cd librocksdb_sys && cargo clean

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,7 @@ fn custom_merge() {
     let mut cf_opts = ColumnFamilyOptions::new();
     cf_opts.add_merge_operator("test operator", concat_merge);
     {
-        let db = DB::open_cf(opts, path, vec!["default"], vec![cf_opts]).unwrap();
+        let db = DB::open_cf(opts, path, vec![("default", cf_opts)]).unwrap();
         db.put(b"k1", b"a").unwrap();
         db.merge(b"k1", b"b").unwrap();
         db.merge(b"k1", b"c").unwrap();
@@ -160,7 +160,7 @@ mod tests {
         // let filter = new_bloom_filter(10);
         // opts.set_filter(filter);
 
-        DB::open_cf(opts, path, vec!["default"], vec![cf_opts]).unwrap()
+        DB::open_cf(opts, path, vec![("default", cf_opts)]).unwrap()
     }
 
     // TODO(tyler) unstable

--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -30,7 +30,6 @@ pub struct MergeOperatorCallback {
 pub extern "C" fn destructor_callback(raw_cb: *mut c_void) {
     // turn this back into a local variable so rust will reclaim it
     let _: Box<MergeOperatorCallback> = unsafe { mem::transmute(raw_cb) };
-
 }
 
 pub extern "C" fn name_callback(raw_cb: *mut c_void) -> *const c_char {
@@ -190,8 +189,7 @@ mod test {
         let db = DB::open_cf(
             opts,
             path.path().to_str().unwrap(),
-            vec!["default"],
-            vec![cf_opts],
+            vec![("default", cf_opts)],
         ).unwrap();
         let p = db.put(b"k1", b"a");
         assert!(p.is_ok());

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -363,15 +363,15 @@ impl DB {
         const ERR_NULL_DB_ONINIT: &str = "Could not initialize database";
         const ERR_NULL_CF_HANDLE: &str = "Received null column family handle from DB";
 
-        let cpath = CString::new(path.as_bytes()).map_err(|_| ERR_CONVERT_PATH.to_owned())?;
-        fs::create_dir_all(&Path::new(path)).map_err(|e| {
+        let cpath = try!(CString::new(path.as_bytes()).map_err(|_| ERR_CONVERT_PATH.to_owned()));
+        try!(fs::create_dir_all(&Path::new(path)).map_err(|e| {
             format!(
                 "Failed to create rocksdb directory: \
                  src/rocksdb.rs:                              \
                  {:?}",
                 e
             )
-        })?;
+        }));
 
         let mut descs = cfds.into_iter().map(|t| t.into()).collect();
         ensure_default_cf_exists(&mut descs);

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -17,9 +17,9 @@ use crocksdb_ffi::{self, DBBackupEngine, DBCFHandle, DBCompressionType, DBInstan
                    DBPinnableSlice, DBStatisticsHistogramType, DBStatisticsTickerType,
                    DBWriteBatch};
 use libc::{self, c_int, c_void, size_t};
-use rocksdb_options::{ColumnFamilyOptions, CompactOptions, DBOptions, EnvOptions, FlushOptions,
-                      HistogramData, IngestExternalFileOptions, ReadOptions, RestoreOptions,
-                      UnsafeSnap, WriteOptions};
+use rocksdb_options::{ColumnFamilyDescriptor, ColumnFamilyOptions, CompactOptions, DBOptions,
+                      EnvOptions, FlushOptions, HistogramData, IngestExternalFileOptions,
+                      ReadOptions, RestoreOptions, UnsafeSnap, WriteOptions};
 use std::{fs, ptr, slice};
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
@@ -29,8 +29,6 @@ use std::ops::Deref;
 use std::path::Path;
 use std::str::from_utf8;
 use table_properties::TablePropertiesCollection;
-
-const DEFAULT_COLUMN_FAMILY: &'static str = "default";
 
 pub struct CFHandle {
     inner: *mut DBCFHandle,
@@ -48,6 +46,25 @@ impl Drop for CFHandle {
             crocksdb_ffi::crocksdb_column_family_handle_destroy(self.inner);
         }
     }
+}
+
+fn ensure_default_cf_exists<'a>(list: &mut Vec<ColumnFamilyDescriptor<'a>>) {
+    let contains = list.iter().any(|ref cf| cf.is_default());
+    if !contains {
+        list.push(ColumnFamilyDescriptor::default());
+    }
+}
+
+fn split_descriptors<'a>(
+    list: Vec<ColumnFamilyDescriptor<'a>>,
+) -> (Vec<&'a str>, Vec<ColumnFamilyOptions>) {
+    let mut v1 = Vec::with_capacity(list.len());
+    let mut v2 = Vec::with_capacity(list.len());
+    for d in list {
+        v1.push(d.name);
+        v2.push(d.options);
+    }
+    (v1, v2)
 }
 
 fn build_cstring_list(str_list: &[&str]) -> Vec<CString> {
@@ -327,95 +344,88 @@ impl DB {
     }
 
     pub fn open(opts: DBOptions, path: &str) -> Result<DB, String> {
-        DB::open_cf(opts, path, vec![], vec![])
+        let cfds: Vec<&str> = vec![];
+        DB::open_cf(opts, path, cfds)
     }
 
-    pub fn open_cf(
-        opts: DBOptions,
-        path: &str,
-        cfs: Vec<&str>,
-        cf_opts: Vec<ColumnFamilyOptions>,
-    ) -> Result<DB, String> {
-        let cpath = match CString::new(path.as_bytes()) {
-            Ok(c) => c,
-            Err(_) => {
-                return Err(
-                    "Failed to convert path to CString when opening rocksdb".to_owned(),
-                )
-            }
-        };
-        if let Err(e) = fs::create_dir_all(&Path::new(path)) {
-            return Err(format!(
+    pub fn open_cf<'a, T>(opts: DBOptions, path: &str, cfds: Vec<T>) -> Result<DB, String>
+    where
+        T: Into<ColumnFamilyDescriptor<'a>>,
+    {
+        DB::open_cf_internal(opts, path, cfds)
+    }
+
+    fn open_cf_internal<'a, T>(opts: DBOptions, path: &str, cfds: Vec<T>) -> Result<DB, String>
+    where
+        T: Into<ColumnFamilyDescriptor<'a>>,
+    {
+        const ERR_CONVERT_PATH: &str = "Failed to convert path to CString when opening rocksdb";
+        const ERR_NULL_DB_ONINIT: &str = "Could not initialize database";
+        const ERR_NULL_CF_HANDLE: &str = "Received null column family handle from DB";
+
+        let cpath = CString::new(path.as_bytes()).map_err(|_| ERR_CONVERT_PATH.to_owned())?;
+        fs::create_dir_all(&Path::new(path)).map_err(|e| {
+            format!(
                 "Failed to create rocksdb directory: \
                  src/rocksdb.rs:                              \
                  {:?}",
                 e
-            ));
-        }
-        if cfs.len() != cf_opts.len() {
-            return Err(format!("cfs.len() and cf_opts.len() not match."));
-        }
-        let mut cfs_v = cfs;
-        let mut cf_opts_v = cf_opts;
+            )
+        })?;
 
-        let (db, cf_map) = {
-            // Always open the default column family
-            if !cfs_v.contains(&DEFAULT_COLUMN_FAMILY) {
-                cfs_v.push(DEFAULT_COLUMN_FAMILY);
-                cf_opts_v.push(ColumnFamilyOptions::new());
-            }
+        let mut descs = cfds.into_iter().map(|t| t.into()).collect();
+        ensure_default_cf_exists(&mut descs);
 
-            // We need to store our CStrings in an intermediate vector
-            // so that their pointers remain valid.
-            let c_cfs = build_cstring_list(&cfs_v);
+        let (names, options) = split_descriptors(descs);
+        let cstrings = build_cstring_list(&names);
 
-            let cfnames: Vec<*const _> = c_cfs.iter().map(|cf| cf.as_ptr()).collect();
+        let cf_names: Vec<*const _> = cstrings.iter().map(|cs| cs.as_ptr()).collect();
+        let cf_handles: Vec<_> = vec![ptr::null_mut(); cf_names.len()];
+        let cf_options: Vec<_> = options
+            .iter()
+            .map(|x| x.inner as *const crocksdb_ffi::Options)
+            .collect();
 
-            // These handles will be populated by DB.
-            let cfhandles: Vec<_> = cfs_v.iter().map(|_| ptr::null_mut()).collect();
-
-            let cfopts: Vec<_> = cf_opts_v
-                .iter()
-                .map(|x| x.inner as *const crocksdb_ffi::Options)
-                .collect();
-
-            let db = unsafe {
+        let db = {
+            let db_options = opts.inner;
+            let db_path = cpath.as_ptr();
+            let db_cf_size = cf_names.len() as c_int;
+            let db_cf_ptrs = cf_names.as_ptr();
+            let db_cf_opts = cf_options.as_ptr();
+            let db_cf_handles = cf_handles.as_ptr();
+            unsafe {
                 ffi_try!(crocksdb_open_column_families(
-                    opts.inner,
-                    cpath.as_ptr(),
-                    cfs_v.len() as c_int,
-                    cfnames.as_ptr(),
-                    cfopts.as_ptr(),
-                    cfhandles.as_ptr()
+                    db_options,
+                    db_path,
+                    db_cf_size,
+                    db_cf_ptrs,
+                    db_cf_opts,
+                    db_cf_handles
                 ))
-            };
-
-            for handle in &cfhandles {
-                if handle.is_null() {
-                    return Err("Received null column family handle from DB.".to_owned());
-                }
             }
-
-            let mut cf_map = BTreeMap::new();
-            for (n, h) in cfs_v.iter().zip(cfhandles) {
-                cf_map.insert((*n).to_owned(), CFHandle { inner: h });
-            }
-
-            if db.is_null() {
-                return Err("Could not initialize database.".to_owned());
-            }
-
-            (db, cf_map)
         };
+        if cf_handles.iter().any(|h| h.is_null()) {
+            return Err(ERR_NULL_CF_HANDLE.to_owned());
+        }
+        if db.is_null() {
+            return Err(ERR_NULL_DB_ONINIT.to_owned());
+        }
+
+        let cfs = names
+            .into_iter()
+            .zip(cf_handles)
+            .map(|(s, h)| (s.to_owned(), CFHandle { inner: h }))
+            .collect();
 
         Ok(DB {
             inner: db,
-            cfs: cf_map,
+            cfs: cfs,
             path: path.to_owned(),
             opts: opts,
-            _cf_opts: cf_opts_v,
+            _cf_opts: options,
         })
     }
+
 
     pub fn destroy(opts: &DBOptions, path: &str) -> Result<(), String> {
         let cpath = CString::new(path.as_bytes()).unwrap();
@@ -554,9 +564,7 @@ impl DB {
         let cname = match CString::new(name.as_bytes()) {
             Ok(c) => c,
             Err(_) => {
-                return Err(
-                    "Failed to convert path to CString when opening rocksdb".to_owned(),
-                )
+                return Err("Failed to convert path to CString when opening rocksdb".to_owned())
             }
         };
         let cname_ptr = cname.as_ptr();

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -389,7 +389,7 @@ impl DB {
         let db = {
             let db_options = opts.inner;
             let db_path = cpath.as_ptr();
-            let db_cf_size = cf_names.len() as c_int;
+            let db_cfs_count = cf_names.len() as c_int;
             let db_cf_ptrs = cf_names.as_ptr();
             let db_cf_opts = cf_options.as_ptr();
             let db_cf_handles = cf_handles.as_ptr();
@@ -397,7 +397,7 @@ impl DB {
                 ffi_try!(crocksdb_open_column_families(
                     db_options,
                     db_path,
-                    db_cf_size,
+                    db_cfs_count,
                     db_cf_ptrs,
                     db_cf_opts,
                     db_cf_handles

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -15,7 +15,6 @@
 
 use compaction_filter::{new_compaction_filter, CompactionFilter, CompactionFilterHandle};
 use comparator::{self, compare_callback, ComparatorCallback};
-
 use crocksdb_ffi::{self, DBBlockBasedTableOptions, DBCompactOptions, DBCompressionType,
                    DBFlushOptions, DBInfoLogLevel, DBInstance, DBRateLimiter, DBReadOptions,
                    DBRecoveryMode, DBRestoreOptions, DBSnapshot, DBStatisticsHistogramType,
@@ -1158,6 +1157,46 @@ impl ColumnFamilyOptions {
 
     pub fn get_block_cache_usage(&self) -> u64 {
         unsafe { crocksdb_ffi::crocksdb_options_get_block_cache_usage(self.inner) as u64 }
+    }
+}
+
+// ColumnFamilyDescriptor is a pair of column family's name and options.
+pub struct ColumnFamilyDescriptor<'a> {
+    pub name: &'a str,
+    pub options: ColumnFamilyOptions,
+}
+
+impl<'a> ColumnFamilyDescriptor<'a> {
+    const DEFAULT_COLUMN_FAMILY: &'static str = "default";
+
+    pub fn new(name: &'a str, options: ColumnFamilyOptions) -> Self {
+        ColumnFamilyDescriptor { name, options }
+    }
+
+    pub fn is_default(&self) -> bool {
+        self.name == Self::DEFAULT_COLUMN_FAMILY
+    }
+}
+
+impl Default for ColumnFamilyDescriptor<'static> {
+    fn default() -> Self {
+        let name = Self::DEFAULT_COLUMN_FAMILY;
+        let options = ColumnFamilyOptions::new();
+        ColumnFamilyDescriptor::new(name, options)
+    }
+}
+
+impl<'a> From<&'a str> for ColumnFamilyDescriptor<'a> {
+    fn from(name: &'a str) -> Self {
+        let options = ColumnFamilyOptions::new();
+        ColumnFamilyDescriptor::new(name, options)
+    }
+}
+
+impl<'a> From<(&'a str, ColumnFamilyOptions)> for ColumnFamilyDescriptor<'a> {
+    fn from(tuple: (&'a str, ColumnFamilyOptions)) -> Self {
+        let (name, options) = tuple;
+        ColumnFamilyDescriptor::new(name, options)
     }
 }
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,7 @@
-extern crate rocksdb;
-extern crate tempdir;
 extern crate byteorder;
 extern crate crc;
+extern crate rocksdb;
+extern crate tempdir;
 
 mod test_iterator;
 mod test_multithreaded;

--- a/tests/test_column_family.rs
+++ b/tests/test_column_family.rs
@@ -27,7 +27,7 @@ pub fn test_column_family() {
         opts.create_if_missing(true);
         let mut cf_opts = ColumnFamilyOptions::new();
         cf_opts.add_merge_operator("test operator", test_provided_merge);
-        let mut db = DB::open_cf(opts, path_str, vec!["default"], vec![cf_opts]).unwrap();
+        let mut db = DB::open_cf(opts, path_str, vec![("default", cf_opts)]).unwrap();
         let cf_opts = ColumnFamilyOptions::new();
         match db.create_cf("cf1", cf_opts) {
             Ok(_) => println!("cf1 created successfully"),
@@ -42,7 +42,7 @@ pub fn test_column_family() {
     {
         let mut cf_opts = ColumnFamilyOptions::new();
         cf_opts.add_merge_operator("test operator", test_provided_merge);
-        match DB::open_cf(DBOptions::new(), path_str, vec!["default"], vec![cf_opts]) {
+        match DB::open_cf(DBOptions::new(), path_str, vec![("default", cf_opts)]) {
             Ok(_) => panic!(
                 "should not have opened DB successfully without \
                         specifying column
@@ -59,7 +59,7 @@ pub fn test_column_family() {
     {
         let mut cf_opts = ColumnFamilyOptions::new();
         cf_opts.add_merge_operator("test operator", test_provided_merge);
-        match DB::open_cf(DBOptions::new(), path_str, vec!["cf1"], vec![cf_opts]) {
+        match DB::open_cf(DBOptions::new(), path_str, vec![("cf1", cf_opts)]) {
             Ok(_) => println!("successfully opened db with column family"),
             Err(e) => panic!("failed to open db with column family: {}", e),
         }
@@ -68,7 +68,7 @@ pub fn test_column_family() {
     {
         let mut cf_opts = ColumnFamilyOptions::new();
         cf_opts.add_merge_operator("test operator", test_provided_merge);
-        let db = match DB::open_cf(DBOptions::new(), path_str, vec!["cf1"], vec![cf_opts]) {
+        let db = match DB::open_cf(DBOptions::new(), path_str, vec![("cf1", cf_opts)]) {
             Ok(db) => {
                 println!("successfully opened db with column family");
                 db
@@ -116,8 +116,7 @@ pub fn test_column_family() {
         let mut db = DB::open_cf(
             DBOptions::new(),
             path_str,
-            vec!["cf1"],
-            vec![ColumnFamilyOptions::new()],
+            vec![("cf1", ColumnFamilyOptions::new())],
         ).unwrap();
         match db.drop_cf("cf1") {
             Ok(_) => println!("cf1 successfully dropped."),

--- a/tests/test_compaction_filter.rs
+++ b/tests/test_compaction_filter.rs
@@ -59,8 +59,7 @@ fn test_compaction_filter() {
     let db = DB::open_cf(
         opts,
         path.path().to_str().unwrap(),
-        vec!["default"],
-        vec![cf_opts],
+        vec![("default", cf_opts)],
     ).unwrap();
     let samples = vec![
         (b"key1".to_vec(), b"value1".to_vec()),
@@ -101,8 +100,7 @@ fn test_compaction_filter() {
         let db = DB::open_cf(
             opts,
             path.path().to_str().unwrap(),
-            vec!["default"],
-            vec![cf_opts],
+            vec![("default", cf_opts)],
         ).unwrap();
         let _snap = db.snapshot();
         // Because ignore_snapshots is true, so all the keys will be compacted.

--- a/tests/test_delete_files_in_range.rs
+++ b/tests/test_delete_files_in_range.rs
@@ -22,7 +22,7 @@ fn initial_data(path: &str) -> DB {
     // DeleteFilesInRange ignore sst files in level 0,
     // this will makes all sst files fall into level 1.
     cf_opts.set_level_zero_file_num_compaction_trigger(1);
-    let db = DB::open_cf(opts, path, vec!["default"], vec![cf_opts]).unwrap();
+    let db = DB::open_cf(opts, path, vec![("default", cf_opts)]).unwrap();
     for i in 0..3 {
         let k = format!("key{}", i);
         let v = format!("value{}", i);

--- a/tests/test_delete_range.rs
+++ b/tests/test_delete_range.rs
@@ -646,7 +646,7 @@ fn test_delete_range_prefix_bloom_case_1() {
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
-    let db = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
+    let db = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
 
     let samples_a = vec![
         (b"keya11111", b"value1"),
@@ -721,7 +721,7 @@ fn test_delete_range_prefix_bloom_case_2() {
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
-    let db = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
+    let db = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
     let handle = get_cf_handle(&db, cf).unwrap();
 
     let samples_a = vec![
@@ -777,7 +777,7 @@ fn test_delete_range_prefix_bloom_case_2() {
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
-    let db2 = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
+    let db2 = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
     let handle2 = get_cf_handle(&db2, cf).unwrap();
 
     db2.ingest_external_file_cf(handle2, &ingest_opt, &[test_sstfile_str])
@@ -814,7 +814,7 @@ fn test_delete_range_prefix_bloom_case_3() {
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
-    let db = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
+    let db = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
     let handle = get_cf_handle(&db, cf).unwrap();
     let samples_a = vec![
         (b"keya11111", b"value1"),
@@ -859,7 +859,7 @@ fn test_delete_range_prefix_bloom_case_3() {
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
-    let db2 = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
+    let db2 = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
     let handle2 = get_cf_handle(&db2, cf).unwrap();
     let samples_b = vec![(b"keyb22222", b"value2"), (b"keyc33333", b"value3")];
     for (k, v) in samples_b {
@@ -910,7 +910,7 @@ fn test_delete_range_prefix_bloom_case_4() {
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
-    let db = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
+    let db = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
     let handle = get_cf_handle(&db, cf).unwrap();
     let samples_a = vec![
         (b"keya11111", b"value1"),
@@ -955,7 +955,7 @@ fn test_delete_range_prefix_bloom_case_4() {
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
-    let db2 = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
+    let db2 = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
     let handle2 = get_cf_handle(&db2, cf).unwrap();
 
 
@@ -1009,7 +1009,7 @@ fn test_delete_range_prefix_bloom_case_5() {
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
-    let db = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
+    let db = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
     let handle = get_cf_handle(&db, cf).unwrap();
     let samples_a = vec![
         (b"keya11111", b"value1"),
@@ -1051,7 +1051,7 @@ fn test_delete_range_prefix_bloom_case_5() {
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
-    let db2 = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
+    let db2 = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
     let handle2 = get_cf_handle(&db2, cf).unwrap();
 
     let samples_b = vec![(b"keyd44444", b"value4"), (b"keye55555", b"value5")];
@@ -1101,7 +1101,7 @@ fn test_delete_range_prefix_bloom_case_6() {
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
-    let db = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
+    let db = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
     let handle = get_cf_handle(&db, cf).unwrap();
     let samples_a = vec![
         (b"keya11111", b"value1"),
@@ -1145,7 +1145,7 @@ fn test_delete_range_prefix_bloom_case_6() {
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
-    let db2 = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
+    let db2 = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
     let handle2 = get_cf_handle(&db2, cf).unwrap();
 
     let samples_b = vec![
@@ -1219,7 +1219,7 @@ fn test_delete_range_prefix_bloom_compact_case() {
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
-    let db = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
+    let db = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
     let handle = get_cf_handle(&db, cf).unwrap();
     let samples_a = vec![
         (b"keya11111", b"value1"),
@@ -1263,7 +1263,7 @@ fn test_delete_range_prefix_bloom_compact_case() {
         .unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
-    let db2 = DB::open_cf(opts, path_str, vec![cf], vec![cf_opts]).unwrap();
+    let db2 = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
     let handle2 = get_cf_handle(&db2, cf).unwrap();
 
     let samples_b = vec![

--- a/tests/test_event_listener.rs
+++ b/tests/test_event_listener.rs
@@ -17,7 +17,6 @@ use rocksdb::*;
 use std::sync::Arc;
 use std::sync::atomic::*;
 use tempdir::TempDir;
-
 use test_ingest_external_file::gen_sst;
 
 #[derive(Default, Clone)]

--- a/tests/test_ingest_external_file.rs
+++ b/tests/test_ingest_external_file.rs
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 use rocksdb::*;
-
 use std::fs;
 use tempdir::TempDir;
 
@@ -157,7 +156,7 @@ fn test_ingest_external_file_new() {
     opts.create_if_missing(true);
     let mut cf_opts = ColumnFamilyOptions::new();
     cf_opts.add_merge_operator("merge operator", concat_merge);
-    let db = DB::open_cf(opts, path_str, vec!["default"], vec![cf_opts]).unwrap();
+    let db = DB::open_cf(opts, path_str, vec![("default", cf_opts)]).unwrap();
     let gen_path = TempDir::new("_rust_rocksdb_ingest_sst_gen_new").expect("");
     let test_sstfile = gen_path.path().join("test_sst_file_new");
     let test_sstfile_str = test_sstfile.to_str().unwrap();

--- a/tests/test_iterator.rs
+++ b/tests/test_iterator.rs
@@ -272,8 +272,7 @@ fn test_total_order_seek() {
     let db = DB::open_cf(
         opts,
         path.path().to_str().unwrap(),
-        vec!["default"],
-        vec![cf_opts],
+        vec![("default", cf_opts)],
     ).unwrap();
     let wopts = WriteOptions::new();
 
@@ -355,8 +354,7 @@ fn test_fixed_suffix_seek() {
     let db = DB::open_cf(
         opts,
         path.path().to_str().unwrap(),
-        vec!["default"],
-        vec![cf_opts],
+        vec![("default", cf_opts)],
     ).unwrap();
     db.put(b"k-eghe-5", b"a").unwrap();
     db.put(b"k-24yfae-6", b"a").unwrap();

--- a/tests/test_prefix_extractor.rs
+++ b/tests/test_prefix_extractor.rs
@@ -77,8 +77,7 @@ fn test_prefix_extractor_compatibility() {
         let db = DB::open_cf(
             opts,
             path.path().to_str().unwrap(),
-            vec!["default"],
-            vec![cf_opts],
+            vec![("default", cf_opts)],
         ).unwrap();
         let wopts = WriteOptions::new();
 

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -33,8 +33,7 @@ fn test_set_num_levels() {
     let db = DB::open_cf(
         opts,
         path.path().to_str().unwrap(),
-        vec!["default"],
-        vec![cf_opts],
+        vec![("default", cf_opts)],
     ).unwrap();
     drop(db);
 }
@@ -127,8 +126,7 @@ fn test_memtable_insert_hint_prefix_extractor() {
     let db = DB::open_cf(
         opts,
         path.path().to_str().unwrap(),
-        vec!["default"],
-        vec![cf_opts],
+        vec![("default", cf_opts)],
     ).unwrap();
     let wopts = WriteOptions::new();
 
@@ -261,8 +259,7 @@ fn test_set_pin_l0_filter_and_index_blocks_in_cache() {
     DB::open_cf(
         opts,
         path.path().to_str().unwrap(),
-        vec!["default"],
-        vec![cf_opts],
+        vec![("default", cf_opts)],
     ).unwrap();
 }
 #[test]
@@ -276,8 +273,7 @@ fn test_pending_compaction_bytes_limit() {
     DB::open_cf(
         opts,
         path.path().to_str().unwrap(),
-        vec!["default"],
-        vec![cf_opts],
+        vec![("default", cf_opts)],
     ).unwrap();
 }
 
@@ -310,8 +306,7 @@ fn test_set_optimize_filters_for_hits() {
     DB::open_cf(
         opts,
         path.path().to_str().unwrap(),
-        vec!["default"],
-        vec![cf_opts],
+        vec![("default", cf_opts)],
     ).unwrap();
 }
 
@@ -330,8 +325,7 @@ fn test_get_block_cache_usage() {
     let db = DB::open_cf(
         opts,
         path.path().to_str().unwrap(),
-        vec!["default"],
-        vec![cf_opts],
+        vec![("default", cf_opts)],
     ).unwrap();
 
     for i in 0..200 {
@@ -355,8 +349,7 @@ fn test_set_level_compaction_dynamic_level_bytes() {
     DB::open_cf(
         opts,
         path.path().to_str().unwrap(),
-        vec!["default"],
-        vec![cf_opts],
+        vec![("default", cf_opts)],
     ).unwrap();
 }
 
@@ -412,8 +405,7 @@ fn test_set_compaction_pri() {
     DB::open_cf(
         opts,
         path.path().to_str().unwrap(),
-        vec!["default"],
-        vec![cf_opts],
+        vec![("default", cf_opts)],
     ).unwrap();
 }
 
@@ -488,8 +480,7 @@ fn test_bottommost_compression() {
     DB::open_cf(
         opts,
         path.path().to_str().unwrap(),
-        vec!["default"],
-        vec![cf_opts],
+        vec![("default", cf_opts)],
     ).unwrap();
 }
 
@@ -577,7 +568,7 @@ fn test_block_based_options() {
     let mut cfopts = ColumnFamilyOptions::new();
     cfopts.set_block_based_table_factory(&bopts);
 
-    let db = DB::open_cf(opts.clone(), path_str, vec!["default"], vec![cfopts]).unwrap();
+    let db = DB::open_cf(opts.clone(), path_str, vec![("default", cfopts)]).unwrap();
     // RocksDB use randomness for the read amplification statistics,
     // we should use a bigger enough value (> `bytes_per_bit`) to make
     // sure the statistics will not be 0.

--- a/tests/test_slice_transform.rs
+++ b/tests/test_slice_transform.rs
@@ -51,8 +51,7 @@ fn test_slice_transform() {
     let db = DB::open_cf(
         opts,
         path.path().to_str().unwrap(),
-        vec!["default"],
-        vec![cf_opts],
+        vec![("default", cf_opts)],
     ).unwrap();
     let samples = vec![
         (b"key_01".to_vec(), b"1".to_vec()),

--- a/tests/test_table_properties.rs
+++ b/tests/test_table_properties.rs
@@ -176,8 +176,7 @@ fn test_table_properties_collector_factory() {
     let db = DB::open_cf(
         opts,
         path.path().to_str().unwrap(),
-        vec!["default"],
-        vec![cf_opts],
+        vec![("default", cf_opts)],
     ).unwrap();
 
     let samples = vec![


### PR DESCRIPTION
This change breaks API, but makes code more clean and readable too.