### PR TITLE
iterator: use deref instead of pure db reference

### DIFF
--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -97,16 +97,14 @@ pub struct WriteBatch {
 
 unsafe impl Send for WriteBatch {}
 
-pub struct Snapshot<'a> {
-    db: &'a DB,
+pub struct Snapshot<D: Deref<Target = DB>> {
+    db: D,
     snap: UnsafeSnap,
 }
 
-// We need to find a better way to add a lifetime in here.
-#[allow(dead_code)]
-pub struct DBIterator<'a> {
-    db: &'a DB,
-    readopts: ReadOptions,
+pub struct DBIterator<D: Deref<Target = DB>> {
+    _db: D,
+    _readopts: ReadOptions,
     inner: *mut crocksdb_ffi::DBIterator,
 }
 
@@ -122,14 +120,14 @@ impl<'a> From<&'a [u8]> for SeekKey<'a> {
     }
 }
 
-impl<'a> DBIterator<'a> {
-    pub fn new(db: &'a DB, readopts: ReadOptions) -> DBIterator<'a> {
+impl<D: Deref<Target = DB>> DBIterator<D> {
+    pub fn new(db: D, readopts: ReadOptions) -> DBIterator<D> {
         unsafe {
             let iterator = crocksdb_ffi::crocksdb_create_iterator(db.inner, readopts.get_inner());
 
             DBIterator {
-                db: db,
-                readopts: readopts,
+                _db: db,
+                _readopts: readopts,
                 inner: iterator,
             }
         }
@@ -209,7 +207,7 @@ impl<'a> DBIterator<'a> {
         unsafe { crocksdb_ffi::crocksdb_iter_valid(self.inner) }
     }
 
-    pub fn new_cf(db: &'a DB, cf_handle: &CFHandle, readopts: ReadOptions) -> DBIterator<'a> {
+    pub fn new_cf(db: D, cf_handle: &CFHandle, readopts: ReadOptions) -> DBIterator<D> {
         unsafe {
             let iterator = crocksdb_ffi::crocksdb_create_iterator_cf(
                 db.inner,
@@ -217,8 +215,8 @@ impl<'a> DBIterator<'a> {
                 cf_handle.inner,
             );
             DBIterator {
-                db: db,
-                readopts: readopts,
+                _db: db,
+                _readopts: readopts,
                 inner: iterator,
             }
         }
@@ -227,7 +225,7 @@ impl<'a> DBIterator<'a> {
 
 pub type Kv = (Vec<u8>, Vec<u8>);
 
-impl<'b, 'a> Iterator for &'b mut DBIterator<'a> {
+impl<'b, D: Deref<Target = DB>> Iterator for &'b mut DBIterator<D> {
     type Item = Kv;
 
     fn next(&mut self) -> Option<Kv> {
@@ -239,7 +237,7 @@ impl<'b, 'a> Iterator for &'b mut DBIterator<'a> {
     }
 }
 
-impl<'a> Drop for DBIterator<'a> {
+impl<D: Deref<Target = DB>> Drop for DBIterator<D> {
     fn drop(&mut self) {
         unsafe {
             crocksdb_ffi::crocksdb_iter_destroy(self.inner);
@@ -247,26 +245,44 @@ impl<'a> Drop for DBIterator<'a> {
     }
 }
 
-impl<'a> Snapshot<'a> {
-    pub fn new(db: &DB) -> Snapshot {
+unsafe impl<D: Deref<Target = DB> + Send> Send for DBIterator<D> {}
+
+unsafe impl<D: Deref<Target = DB> + Send + Sync> Send for Snapshot<D> {}
+unsafe impl<D: Deref<Target = DB> + Send + Sync> Sync for Snapshot<D> {}
+
+impl<D: Deref<Target = DB> + Clone> Snapshot<D> {
+    /// Create an iterator and clone the inner db.
+    ///
+    /// Please note that, the snapshot struct could be dropped before the iterator
+    /// if use improperly, which seems safe though.
+    pub fn iter_opt_clone(&self, mut opt: ReadOptions) -> DBIterator<D> {
+        unsafe {
+            opt.set_snapshot(&self.snap);
+        }
+        DBIterator::new(self.db.clone(), opt)
+    }
+}
+
+impl<D: Deref<Target = DB>> Snapshot<D> {
+    pub fn new(db: D) -> Snapshot<D> {
         unsafe {
             Snapshot {
-                db: db,
                 snap: db.unsafe_snap(),
+                db: db,
             }
         }
     }
 
-    pub fn iter(&self) -> DBIterator {
+    pub fn iter(&self) -> DBIterator<&DB> {
         let readopts = ReadOptions::new();
         self.iter_opt(readopts)
     }
 
-    pub fn iter_opt(&self, mut opt: ReadOptions) -> DBIterator {
+    pub fn iter_opt(&self, mut opt: ReadOptions) -> DBIterator<&DB> {
         unsafe {
             opt.set_snapshot(&self.snap);
         }
-        DBIterator::new(self.db, opt)
+        DBIterator::new(&self.db, opt)
     }
 
     pub fn get(&self, key: &[u8]) -> Result<Option<DBVector>, String> {
@@ -286,7 +302,7 @@ impl<'a> Snapshot<'a> {
     }
 }
 
-impl<'a> Drop for Snapshot<'a> {
+impl<D: Deref<Target = DB>> Drop for Snapshot<D> {
     fn drop(&mut self) {
         unsafe { self.db.release_snap(&self.snap) }
     }
@@ -606,7 +622,9 @@ impl DB {
         let cname = match CString::new(name.as_bytes()) {
             Ok(c) => c,
             Err(_) => {
-                return Err("Failed to convert path to CString when opening rocksdb".to_owned())
+                return Err(
+                    "Failed to convert path to CString when opening rocksdb".to_owned(),
+                )
             }
         };
         let cname_ptr = cname.as_ptr();
@@ -650,25 +668,25 @@ impl DB {
         self.cfs.iter().map(|(k, _)| k.as_str()).collect()
     }
 
-    pub fn iter(&self) -> DBIterator {
+    pub fn iter(&self) -> DBIterator<&DB> {
         let opts = ReadOptions::new();
         self.iter_opt(opts)
     }
 
-    pub fn iter_opt(&self, opt: ReadOptions) -> DBIterator {
+    pub fn iter_opt(&self, opt: ReadOptions) -> DBIterator<&DB> {
         DBIterator::new(&self, opt)
     }
 
-    pub fn iter_cf(&self, cf_handle: &CFHandle) -> DBIterator {
+    pub fn iter_cf(&self, cf_handle: &CFHandle) -> DBIterator<&DB> {
         let opts = ReadOptions::new();
         DBIterator::new_cf(self, cf_handle, opts)
     }
 
-    pub fn iter_cf_opt(&self, cf_handle: &CFHandle, opts: ReadOptions) -> DBIterator {
+    pub fn iter_cf_opt(&self, cf_handle: &CFHandle, opts: ReadOptions) -> DBIterator<&DB> {
         DBIterator::new_cf(self, cf_handle, opts)
     }
 
-    pub fn snapshot(&self) -> Snapshot {
+    pub fn snapshot(&self) -> Snapshot<&DB> {
         Snapshot::new(self)
     }
 


### PR DESCRIPTION
It's intuitive to hold a lifetime for iterator because it's safe and sound as long as the underlying database is not dropped. However, we usually wrap database into an `Arc` in threaded code. In this case, lifetime is not necessary anymore as we can always clone the database. And a lifetime will make it hard to store and update an iterator in a struct due to the self-reference problem (this may be improved in the future in rust), which is very important to write lazy asynchronous code.

So this pr makes iterator constructor accept a `Deref` instead of a `&DB`, so we can pass `&DB`, `Arc<DB>` or anything else as we need.