### PR TITLE
build: check rocksdb version when compiling

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -33,6 +33,14 @@
 #include "rocksdb/write_batch.h"
 #include <stdlib.h>
 
+#if !defined(ROCKSDB_MAJOR) || !defined(ROCKSDB_MINOR) || !defined(ROCKSDB_PATCH)
+#error Only rocksdb 5.7.3+ is supported.
+#endif
+
+#if ROCKSDB_MAJOR * 10000 + ROCKSDB_MINOR * 100 + ROCKSDB_PATCH < 50703
+#error Only rocksdb 5.7.3+ is supported.
+#endif
+
 using rocksdb::Cache;
 using rocksdb::ColumnFamilyDescriptor;
 using rocksdb::ColumnFamilyHandle;


### PR DESCRIPTION
Add version check so that we can know exactly what's going wrong instead of a bunch of declaration error.