### PR TITLE
Update rate_limiter api

### DIFF
--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -168,7 +168,7 @@ impl RateLimiter {
         RateLimiter { inner: limiter }
     }
 
-    pub fn set_bytes_per_second(&mut self, bytes_per_sec: i64) {
+    pub fn set_bytes_per_second(&self, bytes_per_sec: i64) {
         unsafe {
             crocksdb_ffi::crocksdb_ratelimiter_set_bytes_per_second(self.inner, bytes_per_sec);
         }
@@ -178,7 +178,7 @@ impl RateLimiter {
         unsafe { crocksdb_ffi::crocksdb_ratelimiter_get_singleburst_bytes(self.inner) }
     }
 
-    pub fn request(&mut self, bytes: i64, pri: c_uchar) {
+    pub fn request(&self, bytes: i64, pri: c_uchar) {
         unsafe {
             crocksdb_ffi::crocksdb_ratelimiter_request(self.inner, bytes, pri);
         }

--- a/tests/test_rate_limiter.rs
+++ b/tests/test_rate_limiter.rs
@@ -16,7 +16,7 @@ use rocksdb::RateLimiter;
 
 #[test]
 fn test_rate_limiter() {
-    let mut rate_limiter = RateLimiter::new(10 * 1024 * 1024, 100 * 1000, 10);
+    let rate_limiter = RateLimiter::new(10 * 1024 * 1024, 100 * 1000, 10);
     assert_eq!(rate_limiter.get_singleburst_bytes(), 1 * 1024 * 1024);
 
     rate_limiter.set_bytes_per_second(20 * 1024 * 1024);
@@ -41,7 +41,7 @@ fn test_rate_limiter() {
 
 #[test]
 fn test_rate_limiter_sendable() {
-    let mut rate_limiter = RateLimiter::new(10 * 1024 * 1024, 100 * 1000, 10);
+    let rate_limiter = RateLimiter::new(10 * 1024 * 1024, 100 * 1000, 10);
 
     let handle = thread::spawn(move || {
         rate_limiter.request(1024, 0);


### PR DESCRIPTION
Signed-off-by: UncP <uncp.xu@gmail.com>

The rust-rocksdb::RateLimiter does not have to be mutable, because rocksdb::RateLimiter inside is already mutable.

Created this pr to fix TiKV compilation error.