### PR TITLE
Fix type error

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -1968,6 +1968,10 @@ void crocksdb_options_set_max_bytes_for_level_multiplier(crocksdb_options_t* opt
   opt->rep.max_bytes_for_level_multiplier = n;
 }
 
+double crocksdb_options_get_max_bytes_for_level_multiplier(crocksdb_options_t* opt) {
+  return opt->rep.max_bytes_for_level_multiplier;
+}
+
 void crocksdb_options_set_max_compaction_bytes(crocksdb_options_t* opt,
                                               uint64_t n) {
   opt->rep.max_compaction_bytes = n;

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -784,6 +784,8 @@ crocksdb_options_set_level_compaction_dynamic_level_bytes(crocksdb_options_t*,
                                                          unsigned char);
 extern C_ROCKSDB_LIBRARY_API void
 crocksdb_options_set_max_bytes_for_level_multiplier(crocksdb_options_t*, double);
+extern C_ROCKSDB_LIBRARY_API double
+crocksdb_options_get_max_bytes_for_level_multiplier(crocksdb_options_t*);
 extern C_ROCKSDB_LIBRARY_API void
 crocksdb_options_set_max_bytes_for_level_multiplier_additional(
     crocksdb_options_t*, int* level_values, size_t num_levels);

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -416,7 +416,7 @@ extern "C" {
     pub fn crocksdb_options_set_target_file_size_base(options: *mut Options, bytes: u64);
     pub fn crocksdb_options_set_target_file_size_multiplier(options: *mut Options, mul: c_int);
     pub fn crocksdb_options_set_max_bytes_for_level_base(options: *mut Options, bytes: u64);
-    pub fn crocksdb_options_set_max_bytes_for_level_multiplier(options: *mut Options, mul: c_int);
+    pub fn crocksdb_options_set_max_bytes_for_level_multiplier(options: *mut Options, mul: f64);
     pub fn crocksdb_options_set_max_compaction_bytes(options: *mut Options, bytes: uint64_t);
     pub fn crocksdb_options_set_max_log_file_size(options: *mut Options, bytes: size_t);
     pub fn crocksdb_options_set_log_file_time_to_roll(options: *mut Options, bytes: size_t);

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -417,6 +417,7 @@ extern "C" {
     pub fn crocksdb_options_set_target_file_size_multiplier(options: *mut Options, mul: c_int);
     pub fn crocksdb_options_set_max_bytes_for_level_base(options: *mut Options, bytes: u64);
     pub fn crocksdb_options_set_max_bytes_for_level_multiplier(options: *mut Options, mul: f64);
+    pub fn crocksdb_options_get_max_bytes_for_level_multiplier(options: *mut Options) -> f64;
     pub fn crocksdb_options_set_max_compaction_bytes(options: *mut Options, bytes: uint64_t);
     pub fn crocksdb_options_set_max_log_file_size(options: *mut Options, bytes: size_t);
     pub fn crocksdb_options_set_log_file_time_to_roll(options: *mut Options, bytes: size_t);

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -1078,6 +1078,12 @@ impl ColumnFamilyOptions {
         }
     }
 
+    pub fn get_max_bytes_for_level_multiplier(&mut self) -> i32 {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_get_max_bytes_for_level_multiplier(self.inner) as i32
+        }
+    }
+
     pub fn set_max_compaction_bytes(&mut self, bytes: u64) {
         unsafe {
             crocksdb_ffi::crocksdb_options_set_max_compaction_bytes(self.inner, bytes);

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -1074,7 +1074,7 @@ impl ColumnFamilyOptions {
 
     pub fn set_max_bytes_for_level_multiplier(&mut self, mul: i32) {
         unsafe {
-            crocksdb_ffi::crocksdb_options_set_max_bytes_for_level_multiplier(self.inner, mul);
+            crocksdb_ffi::crocksdb_options_set_max_bytes_for_level_multiplier(self.inner, mul as f64);
         }
     }
 

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -661,3 +661,10 @@ fn test_fifo_compaction_options() {
     cf_opts.set_fifo_compaction_options(fifo_opts);
     DB::open_cf(opts, path_str, vec![("default", cf_opts)]).unwrap();
 }
+
+#[test]
+fn test_readoptions_max_bytes_for_level_multiplier() {
+    let mut cf_opts = ColumnFamilyOptions::new();
+    cf_opts.set_max_bytes_for_level_multiplier(8);
+    assert_eq!(cf_opts.get_max_bytes_for_level_multiplier(), 8);
+}


### PR DESCRIPTION
`crocksdb_options_set_max_bytes_for_level_multiplier` need `double` parameter but we pass `c_int`, it will cause numeric error.