### PR TITLE
[fix] Convert variable-length arrays to std::vector

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -3417,9 +3417,9 @@ void crocksdb_delete_files_in_ranges_cf(
     const char* const* start_keys, const size_t* start_keys_lens,
     const char* const* limit_keys, const size_t* limit_keys_lens,
     size_t num_ranges, bool include_end, char** errptr) {
-  Slice starts[num_ranges];
-  Slice limits[num_ranges];
-  RangePtr ranges[num_ranges];
+  std::vector<Slice> starts(num_ranges);
+  std::vector<Slice> limits(num_ranges);
+  std::vector<RangePtr> ranges(num_ranges);
   for (auto i = 0; i < num_ranges; i++) {
     const Slice* start = nullptr;
     if (start_keys[i]) {
@@ -3436,7 +3436,7 @@ void crocksdb_delete_files_in_ranges_cf(
   SaveError(
       errptr,
       DeleteFilesInRanges(
-          db->rep, cf->rep, ranges, num_ranges, include_end));
+          db->rep, cf->rep, &ranges[0], num_ranges, include_end));
 }
 
 void crocksdb_free(void* ptr) { free(ptr); }


### PR DESCRIPTION
`Apple LLVM (clang)` does not support VLA of non-POD types, leading to the following compilation error for `librocksdb_sys` on MAC OS X:

```
cargo:warning=crocksdb/c.cc:3420:15: error: variable length array of non-POD element type 'rocksdb::Slice'
cargo:warning=  Slice starts[num_ranges];
cargo:warning=              ^
cargo:warning=crocksdb/c.cc:3421:15: error: variable length array of non-POD element type 'rocksdb::Slice'
cargo:warning=  Slice limits[num_ranges];
cargo:warning=              ^
cargo:warning=crocksdb/c.cc:3422:18: error: variable length array of non-POD element type 'rocksdb::RangePtr'
cargo:warning=  RangePtr ranges[num_ranges];
```

Other wrapped calls also use std::vector, hence i'm assuming heap allocation is not prohibited by design.