### PR TITLE
Support building on freebsd

### DIFF
--- a/librocksdb_sys/build.rs
+++ b/librocksdb_sys/build.rs
@@ -91,6 +91,8 @@ fn build_rocksdb() -> Build {
     }
     if cfg!(target_os = "macos") {
         build.define("OS_MACOSX", None);
+    } else if cfg!(target_os = "freebsd") {
+        build.define("OS_FREEBSD", None);
     }
 
     let cur_dir = env::current_dir().unwrap();


### PR DESCRIPTION
Add necessary build flag to support compiling on FreeBSD successfully. A
similar change could be made to support OpenBSD and DragonflyBSD.