### PR TITLE
*: add PerfContext

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -31,6 +31,7 @@
 #include "rocksdb/utilities/backupable_db.h"
 #include "rocksdb/utilities/debug.h"
 #include "rocksdb/write_batch.h"
+#include "rocksdb/perf_context.h"
 
 #include "db/column_family.h"
 #include "table/sst_file_writer_collectors.h"
@@ -135,6 +136,8 @@ using rocksdb::ColumnFamilyMetaData;
 using rocksdb::LevelMetaData;
 using rocksdb::SstFileMetaData;
 using rocksdb::CompactionOptions;
+using rocksdb::PerfLevel;
+using rocksdb::PerfContext;
 
 using std::shared_ptr;
 
@@ -4228,6 +4231,292 @@ void crocksdb_compact_files_cf(
   }
   auto s = db->rep->CompactFiles(opts->rep, cf->rep, input_files, output_level);
   SaveError(errptr, s);
+}
+
+/* PerfContext */
+
+int crocksdb_get_perf_level(void) {
+  return static_cast<int>(rocksdb::GetPerfLevel());
+}
+
+void crocksdb_set_perf_level(int level) {
+  rocksdb::SetPerfLevel(static_cast<PerfLevel>(level));
+}
+
+struct crocksdb_perf_context_t {
+  PerfContext rep;
+};
+
+crocksdb_perf_context_t* crocksdb_get_perf_context(void) {
+  return reinterpret_cast<crocksdb_perf_context_t*>(rocksdb::get_perf_context());
+}
+
+void crocksdb_perf_context_reset(crocksdb_perf_context_t* ctx) {
+  ctx->rep.Reset();
+}
+
+uint64_t crocksdb_perf_context_user_key_comparison_count(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.user_key_comparison_count;
+}
+
+uint64_t crocksdb_perf_context_block_cache_hit_count(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.block_cache_hit_count;
+}
+
+uint64_t crocksdb_perf_context_block_read_count(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.block_read_count;
+}
+
+uint64_t crocksdb_perf_context_block_read_byte(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.block_read_byte;
+}
+
+uint64_t crocksdb_perf_context_block_read_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.block_read_time;
+}
+
+uint64_t crocksdb_perf_context_block_checksum_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.block_checksum_time;
+}
+
+uint64_t crocksdb_perf_context_block_decompress_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.block_decompress_time;
+}
+
+uint64_t crocksdb_perf_context_get_read_bytes(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.get_read_bytes;
+}
+
+uint64_t crocksdb_perf_context_multiget_read_bytes(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.multiget_read_bytes;
+}
+
+uint64_t crocksdb_perf_context_iter_read_bytes(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.iter_read_bytes;
+}
+
+uint64_t crocksdb_perf_context_internal_key_skipped_count(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.internal_key_skipped_count;
+}
+
+uint64_t crocksdb_perf_context_internal_delete_skipped_count(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.internal_delete_skipped_count;
+}
+
+uint64_t crocksdb_perf_context_internal_recent_skipped_count(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.internal_recent_skipped_count;
+}
+
+uint64_t crocksdb_perf_context_internal_merge_count(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.internal_merge_count;
+}
+
+uint64_t crocksdb_perf_context_get_snapshot_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.get_snapshot_time;
+}
+
+uint64_t crocksdb_perf_context_get_from_memtable_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.get_from_memtable_time;
+}
+
+uint64_t crocksdb_perf_context_get_from_memtable_count(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.get_from_memtable_count;
+}
+
+uint64_t crocksdb_perf_context_get_post_process_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.get_post_process_time;
+}
+
+uint64_t crocksdb_perf_context_get_from_output_files_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.get_from_output_files_time;
+}
+
+uint64_t crocksdb_perf_context_seek_on_memtable_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.seek_on_memtable_time;
+}
+
+uint64_t crocksdb_perf_context_seek_on_memtable_count(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.seek_on_memtable_count;
+}
+
+uint64_t crocksdb_perf_context_next_on_memtable_count(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.next_on_memtable_count;
+}
+
+uint64_t crocksdb_perf_context_prev_on_memtable_count(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.prev_on_memtable_count;
+}
+
+uint64_t crocksdb_perf_context_seek_child_seek_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.seek_child_seek_time;
+}
+
+uint64_t crocksdb_perf_context_seek_child_seek_count(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.seek_child_seek_count;
+}
+
+uint64_t crocksdb_perf_context_seek_min_heap_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.seek_min_heap_time;
+}
+
+uint64_t crocksdb_perf_context_seek_max_heap_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.seek_max_heap_time;
+}
+
+uint64_t crocksdb_perf_context_seek_internal_seek_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.seek_internal_seek_time;
+}
+
+uint64_t crocksdb_perf_context_find_next_user_entry_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.find_next_user_entry_time;
+}
+
+uint64_t crocksdb_perf_context_write_wal_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.write_wal_time;
+}
+
+uint64_t crocksdb_perf_context_write_memtable_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.write_memtable_time;
+}
+
+uint64_t crocksdb_perf_context_write_delay_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.write_delay_time;
+}
+
+uint64_t crocksdb_perf_context_write_pre_and_post_process_time(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.write_pre_and_post_process_time;
+}
+
+uint64_t crocksdb_perf_context_db_mutex_lock_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.db_mutex_lock_nanos;
+}
+
+uint64_t crocksdb_perf_context_db_condition_wait_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.db_condition_wait_nanos;
+}
+
+uint64_t crocksdb_perf_context_merge_operator_time_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.merge_operator_time_nanos;
+}
+
+uint64_t crocksdb_perf_context_read_index_block_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.read_index_block_nanos;
+}
+
+uint64_t crocksdb_perf_context_read_filter_block_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.read_filter_block_nanos;
+}
+
+uint64_t crocksdb_perf_context_new_table_block_iter_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.new_table_block_iter_nanos;
+}
+
+uint64_t crocksdb_perf_context_new_table_iterator_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.new_table_iterator_nanos;
+}
+
+uint64_t crocksdb_perf_context_block_seek_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.block_seek_nanos;
+}
+
+uint64_t crocksdb_perf_context_find_table_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.find_table_nanos;
+}
+
+uint64_t crocksdb_perf_context_bloom_memtable_hit_count(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.bloom_memtable_hit_count;
+}
+
+uint64_t crocksdb_perf_context_bloom_memtable_miss_count(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.bloom_memtable_miss_count;
+}
+
+uint64_t crocksdb_perf_context_bloom_sst_hit_count(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.bloom_sst_hit_count;
+}
+
+uint64_t crocksdb_perf_context_bloom_sst_miss_count(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.bloom_sst_miss_count;
+}
+
+uint64_t crocksdb_perf_context_env_new_sequential_file_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_new_sequential_file_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_new_random_access_file_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_new_random_access_file_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_new_writable_file_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_new_writable_file_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_reuse_writable_file_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_reuse_writable_file_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_new_random_rw_file_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_new_random_rw_file_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_new_directory_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_new_directory_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_file_exists_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_file_exists_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_get_children_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_get_children_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_get_children_file_attributes_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_get_children_file_attributes_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_delete_file_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_delete_file_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_create_dir_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_create_dir_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_create_dir_if_missing_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_create_dir_if_missing_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_delete_dir_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_delete_dir_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_get_file_size_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_get_file_size_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_get_file_modification_time_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_get_file_modification_time_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_rename_file_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_rename_file_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_link_file_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_link_file_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_lock_file_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_lock_file_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_unlock_file_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_unlock_file_nanos;
+}
+
+uint64_t crocksdb_perf_context_env_new_logger_nanos(crocksdb_perf_context_t* ctx) {
+  return ctx->rep.env_new_logger_nanos;
 }
 
 }  // end extern "C"

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -136,6 +136,7 @@ typedef struct crocksdb_column_family_meta_data_t crocksdb_column_family_meta_da
 typedef struct crocksdb_level_meta_data_t crocksdb_level_meta_data_t;
 typedef struct crocksdb_sst_file_meta_data_t crocksdb_sst_file_meta_data_t;
 typedef struct crocksdb_compaction_options_t crocksdb_compaction_options_t;
+typedef struct crocksdb_perf_context_t crocksdb_perf_context_t;
 
 typedef enum crocksdb_table_property_t {
   kDataSize = 1,
@@ -1692,6 +1693,146 @@ crocksdb_compact_files_cf(crocksdb_t*, crocksdb_column_family_handle_t*,
                           size_t input_file_count,
                           int output_level,
                           char** errptr);
+
+/* PerfContext */
+extern C_ROCKSDB_LIBRARY_API int crocksdb_get_perf_level(void);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_set_perf_level(int level);
+extern C_ROCKSDB_LIBRARY_API crocksdb_perf_context_t*
+crocksdb_get_perf_context(void);
+extern C_ROCKSDB_LIBRARY_API void
+crocksdb_perf_context_reset(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_user_key_comparison_count(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_block_cache_hit_count(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_block_read_count(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_block_read_byte(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_block_read_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_block_checksum_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_block_decompress_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_get_read_bytes(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_multiget_read_bytes(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_iter_read_bytes(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_internal_key_skipped_count(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_internal_delete_skipped_count(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_internal_recent_skipped_count(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_internal_merge_count(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_get_snapshot_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_get_from_memtable_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_get_from_memtable_count(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_get_post_process_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_get_from_output_files_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_seek_on_memtable_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_seek_on_memtable_count(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_next_on_memtable_count(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_prev_on_memtable_count(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_seek_child_seek_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_seek_child_seek_count(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_seek_min_heap_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_seek_max_heap_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_seek_internal_seek_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_find_next_user_entry_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_write_wal_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_write_memtable_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_write_delay_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_write_pre_and_post_process_time(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_db_mutex_lock_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_db_condition_wait_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_merge_operator_time_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_read_index_block_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_read_filter_block_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_new_table_block_iter_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_new_table_iterator_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_block_seek_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_find_table_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_bloom_memtable_hit_count(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_bloom_memtable_miss_count(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_bloom_sst_hit_count(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_bloom_sst_miss_count(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_new_sequential_file_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_new_random_access_file_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_new_writable_file_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_reuse_writable_file_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_new_random_rw_file_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_new_directory_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_file_exists_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_get_children_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_get_children_file_attributes_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_delete_file_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_create_dir_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_create_dir_if_missing_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_delete_dir_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_get_file_size_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_get_file_modification_time_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_rename_file_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_link_file_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_lock_file_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_unlock_file_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_perf_context_env_new_logger_nanos(crocksdb_perf_context_t*);
 
 #ifdef __cplusplus
 }  /* end extern "C" */

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -66,6 +66,7 @@ pub enum DBColumnFamilyMetaData {}
 pub enum DBLevelMetaData {}
 pub enum DBSstFileMetaData {}
 pub enum DBCompactionOptions {}
+pub enum DBPerfContext {}
 
 pub fn new_bloom_filter(bits: c_int) -> *mut DBFilterPolicy {
     unsafe { crocksdb_filterpolicy_create_bloom(bits) }
@@ -1627,6 +1628,81 @@ extern "C" {
         output_level: c_int,
         errptr: *mut *mut c_char,
     );
+
+    pub fn crocksdb_get_perf_level() -> c_int;
+    pub fn crocksdb_set_perf_level(level: c_int);
+    pub fn crocksdb_get_perf_context() -> *mut DBPerfContext;
+    pub fn crocksdb_perf_context_reset(ctx: *mut DBPerfContext);
+    pub fn crocksdb_perf_context_user_key_comparison_count(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_block_cache_hit_count(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_block_read_count(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_block_read_byte(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_block_read_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_block_checksum_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_block_decompress_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_get_read_bytes(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_multiget_read_bytes(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_iter_read_bytes(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_internal_key_skipped_count(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_internal_delete_skipped_count(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_internal_recent_skipped_count(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_internal_merge_count(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_get_snapshot_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_get_from_memtable_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_get_from_memtable_count(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_get_post_process_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_get_from_output_files_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_seek_on_memtable_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_seek_on_memtable_count(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_next_on_memtable_count(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_prev_on_memtable_count(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_seek_child_seek_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_seek_child_seek_count(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_seek_min_heap_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_seek_max_heap_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_seek_internal_seek_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_find_next_user_entry_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_write_wal_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_write_memtable_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_write_delay_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_write_pre_and_post_process_time(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_db_mutex_lock_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_db_condition_wait_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_merge_operator_time_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_read_index_block_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_read_filter_block_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_new_table_block_iter_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_new_table_iterator_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_block_seek_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_find_table_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_bloom_memtable_hit_count(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_bloom_memtable_miss_count(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_bloom_sst_hit_count(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_bloom_sst_miss_count(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_new_sequential_file_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_new_random_access_file_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_new_writable_file_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_reuse_writable_file_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_new_random_rw_file_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_new_directory_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_file_exists_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_get_children_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_get_children_file_attributes_nanos(
+        ctx: *mut DBPerfContext,
+    ) -> u64;
+    pub fn crocksdb_perf_context_env_delete_file_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_create_dir_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_create_dir_if_missing_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_delete_dir_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_get_file_size_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_get_file_modification_time_nanos(
+        ctx: *mut DBPerfContext,
+    ) -> u64;
+    pub fn crocksdb_perf_context_env_rename_file_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_link_file_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_lock_file_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_unlock_file_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_perf_context_env_new_logger_nanos(ctx: *mut DBPerfContext) -> u64;
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ pub mod comparator;
 mod event_listener;
 pub mod merge_operator;
 mod metadata;
+mod perf_context;
 pub mod rocksdb;
 pub mod rocksdb_options;
 mod slice_transform;
@@ -40,6 +41,7 @@ pub use librocksdb_sys::{self as crocksdb_ffi, new_bloom_filter, CompactionPrior
                          DBRecoveryMode, DBStatisticsHistogramType, DBStatisticsTickerType};
 pub use merge_operator::MergeOperands;
 pub use metadata::{ColumnFamilyMetaData, LevelMetaData, SstFileMetaData};
+pub use perf_context::{get_perf_level, set_perf_level, PerfContext, PerfLevel};
 pub use rocksdb::{set_external_sst_file_global_seq_no, BackupEngine, CFHandle, DBIterator,
                   DBVector, Env, ExternalSstFileInfo, Kv, Range, SeekKey, SequentialFile,
                   SstFileWriter, Writable, WriteBatch, DB};

--- a/src/perf_context.rs
+++ b/src/perf_context.rs
@@ -1,0 +1,392 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crocksdb_ffi::{self, DBPerfContext};
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum PerfLevel {
+    Uninitialized,
+    Disable,
+    EnableCount,
+    EnableTimeExceptForMutex,
+    EnableTime,
+    OutOfBounds,
+}
+
+pub fn get_perf_level() -> PerfLevel {
+    let v = unsafe { crocksdb_ffi::crocksdb_get_perf_level() };
+    match v {
+        0 => PerfLevel::Uninitialized,
+        1 => PerfLevel::Disable,
+        2 => PerfLevel::EnableCount,
+        3 => PerfLevel::EnableTimeExceptForMutex,
+        4 => PerfLevel::EnableTime,
+        5 => PerfLevel::OutOfBounds,
+        _ => unreachable!(),
+    }
+}
+
+pub fn set_perf_level(level: PerfLevel) {
+    let v = match level {
+        PerfLevel::Uninitialized => 0,
+        PerfLevel::Disable => 1,
+        PerfLevel::EnableCount => 2,
+        PerfLevel::EnableTimeExceptForMutex => 3,
+        PerfLevel::EnableTime => 4,
+        PerfLevel::OutOfBounds => 5,
+    };
+    unsafe {
+        crocksdb_ffi::crocksdb_set_perf_level(v);
+    }
+}
+
+pub struct PerfContext {
+    inner: *mut DBPerfContext,
+}
+
+impl PerfContext {
+    pub fn get() -> PerfContext {
+        unsafe {
+            PerfContext {
+                inner: crocksdb_ffi::crocksdb_get_perf_context(),
+            }
+        }
+    }
+
+    pub fn reset(&mut self) {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_reset(self.inner) }
+    }
+
+    pub fn user_key_comparison_count(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_user_key_comparison_count(self.inner) }
+    }
+
+    pub fn block_cache_hit_count(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_block_cache_hit_count(self.inner) }
+    }
+
+    pub fn block_read_count(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_block_read_count(self.inner) }
+    }
+
+    pub fn block_read_byte(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_block_read_byte(self.inner) }
+    }
+
+    pub fn block_read_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_block_read_time(self.inner) }
+    }
+
+    pub fn block_checksum_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_block_checksum_time(self.inner) }
+    }
+
+    pub fn block_decompress_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_block_decompress_time(self.inner) }
+    }
+
+    pub fn get_read_bytes(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_get_read_bytes(self.inner) }
+    }
+
+    pub fn multiget_read_bytes(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_multiget_read_bytes(self.inner) }
+    }
+
+    pub fn iter_read_bytes(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_iter_read_bytes(self.inner) }
+    }
+
+    pub fn internal_key_skipped_count(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_internal_key_skipped_count(self.inner) }
+    }
+
+    pub fn internal_delete_skipped_count(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_internal_delete_skipped_count(self.inner) }
+    }
+
+    pub fn internal_recent_skipped_count(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_internal_recent_skipped_count(self.inner) }
+    }
+
+    pub fn internal_merge_count(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_internal_merge_count(self.inner) }
+    }
+
+    pub fn get_snapshot_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_get_snapshot_time(self.inner) }
+    }
+
+    pub fn get_from_memtable_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_get_from_memtable_time(self.inner) }
+    }
+
+    pub fn get_from_memtable_count(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_get_from_memtable_count(self.inner) }
+    }
+
+    pub fn get_post_process_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_get_post_process_time(self.inner) }
+    }
+
+    pub fn get_from_output_files_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_get_from_output_files_time(self.inner) }
+    }
+
+    pub fn seek_on_memtable_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_seek_on_memtable_time(self.inner) }
+    }
+
+    pub fn seek_on_memtable_count(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_seek_on_memtable_count(self.inner) }
+    }
+
+    pub fn next_on_memtable_count(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_next_on_memtable_count(self.inner) }
+    }
+
+    pub fn prev_on_memtable_count(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_prev_on_memtable_count(self.inner) }
+    }
+
+    pub fn seek_child_seek_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_seek_child_seek_time(self.inner) }
+    }
+
+    pub fn seek_child_seek_count(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_seek_child_seek_count(self.inner) }
+    }
+
+    pub fn seek_min_heap_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_seek_min_heap_time(self.inner) }
+    }
+
+    pub fn seek_max_heap_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_seek_max_heap_time(self.inner) }
+    }
+
+    pub fn seek_internal_seek_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_seek_internal_seek_time(self.inner) }
+    }
+
+    pub fn find_next_user_entry_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_find_next_user_entry_time(self.inner) }
+    }
+
+    pub fn write_wal_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_write_wal_time(self.inner) }
+    }
+
+    pub fn write_memtable_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_write_memtable_time(self.inner) }
+    }
+
+    pub fn write_delay_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_write_delay_time(self.inner) }
+    }
+
+    pub fn write_pre_and_post_process_time(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_write_pre_and_post_process_time(self.inner) }
+    }
+
+    pub fn db_mutex_lock_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_db_mutex_lock_nanos(self.inner) }
+    }
+
+    pub fn db_condition_wait_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_db_condition_wait_nanos(self.inner) }
+    }
+
+    pub fn merge_operator_time_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_merge_operator_time_nanos(self.inner) }
+    }
+
+    pub fn read_index_block_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_read_index_block_nanos(self.inner) }
+    }
+
+    pub fn read_filter_block_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_read_filter_block_nanos(self.inner) }
+    }
+
+    pub fn new_table_block_iter_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_new_table_block_iter_nanos(self.inner) }
+    }
+
+    pub fn new_table_iterator_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_new_table_iterator_nanos(self.inner) }
+    }
+
+    pub fn block_seek_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_block_seek_nanos(self.inner) }
+    }
+
+    pub fn find_table_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_find_table_nanos(self.inner) }
+    }
+
+    pub fn bloom_memtable_hit_count(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_bloom_memtable_hit_count(self.inner) }
+    }
+
+    pub fn bloom_memtable_miss_count(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_bloom_memtable_miss_count(self.inner) }
+    }
+
+    pub fn bloom_sst_hit_count(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_bloom_sst_hit_count(self.inner) }
+    }
+
+    pub fn bloom_sst_miss_count(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_bloom_sst_miss_count(self.inner) }
+    }
+
+    pub fn env_new_sequential_file_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_new_sequential_file_nanos(self.inner) }
+    }
+
+    pub fn env_new_random_access_file_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_new_random_access_file_nanos(self.inner) }
+    }
+
+    pub fn env_new_writable_file_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_new_writable_file_nanos(self.inner) }
+    }
+
+    pub fn env_reuse_writable_file_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_reuse_writable_file_nanos(self.inner) }
+    }
+
+    pub fn env_new_random_rw_file_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_new_random_rw_file_nanos(self.inner) }
+    }
+
+    pub fn env_new_directory_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_new_directory_nanos(self.inner) }
+    }
+
+    pub fn env_file_exists_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_file_exists_nanos(self.inner) }
+    }
+
+    pub fn env_get_children_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_get_children_nanos(self.inner) }
+    }
+
+    pub fn env_get_children_file_attributes_nanos(&self) -> u64 {
+        unsafe {
+            crocksdb_ffi::crocksdb_perf_context_env_get_children_file_attributes_nanos(self.inner)
+        }
+    }
+
+    pub fn env_delete_file_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_delete_file_nanos(self.inner) }
+    }
+
+    pub fn env_create_dir_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_create_dir_nanos(self.inner) }
+    }
+
+    pub fn env_create_dir_if_missing_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_create_dir_if_missing_nanos(self.inner) }
+    }
+
+    pub fn env_delete_dir_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_delete_dir_nanos(self.inner) }
+    }
+
+    pub fn env_get_file_size_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_get_file_size_nanos(self.inner) }
+    }
+
+    pub fn env_get_file_modification_time_nanos(&self) -> u64 {
+        unsafe {
+            crocksdb_ffi::crocksdb_perf_context_env_get_file_modification_time_nanos(self.inner)
+        }
+    }
+
+    pub fn env_rename_file_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_rename_file_nanos(self.inner) }
+    }
+
+    pub fn env_link_file_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_link_file_nanos(self.inner) }
+    }
+
+    pub fn env_lock_file_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_lock_file_nanos(self.inner) }
+    }
+
+    pub fn env_unlock_file_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_unlock_file_nanos(self.inner) }
+    }
+
+    pub fn env_new_logger_nanos(&self) -> u64 {
+        unsafe { crocksdb_ffi::crocksdb_perf_context_env_new_logger_nanos(self.inner) }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use tempdir::TempDir;
+
+    use rocksdb::{SeekKey, Writable, DB};
+    use rocksdb_options::DBOptions;
+
+    #[test]
+    fn test_perf_context() {
+        let temp_dir = TempDir::new("test_perf_context").unwrap();
+        let mut opts = DBOptions::new();
+        opts.create_if_missing(true);
+        let db = DB::open(opts, temp_dir.path().to_str().unwrap()).unwrap();
+
+        let n = 10;
+        for i in 0..n {
+            let k = &[i as u8];
+            db.put(k, k).unwrap();
+            if i % 2 == 0 {
+                db.delete(k).unwrap();
+            }
+        }
+
+        let mut ctx = PerfContext::get();
+
+        let mut iter = db.iter();
+        assert!(iter.seek(SeekKey::Start));
+        while iter.valid() {
+            iter.next();
+        }
+        assert_eq!(ctx.internal_key_skipped_count(), n);
+        assert_eq!(ctx.internal_delete_skipped_count(), n / 2);
+        assert_eq!(ctx.seek_internal_seek_time(), 0);
+
+        ctx.reset();
+        assert_eq!(ctx.internal_key_skipped_count(), 0);
+        assert_eq!(ctx.internal_delete_skipped_count(), 0);
+
+        assert_eq!(get_perf_level(), PerfLevel::EnableCount);
+        set_perf_level(PerfLevel::EnableTime);
+        assert_eq!(get_perf_level(), PerfLevel::EnableTime);
+
+        let mut iter = db.iter();
+        assert!(iter.seek(SeekKey::End));
+        while iter.valid() {
+            iter.prev();
+        }
+        assert_eq!(ctx.internal_key_skipped_count(), n + n / 2);
+        assert_eq!(ctx.internal_delete_skipped_count(), n / 2);
+        assert_ne!(ctx.seek_internal_seek_time(), 0);
+    }
+}


### PR DESCRIPTION
Exploit the `PerfContext` for better debugging. See the test for example usage.
Most of the code in this PR is boring and is generated by a script :)