### PR TITLE
Provide an optimized file ingestion method

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -3201,6 +3201,11 @@ void crocksdb_flushoptions_set_wait(
   opt->rep.wait = v;
 }
 
+void crocksdb_flushoptions_set_allow_write_stall(
+    crocksdb_flushoptions_t* opt, unsigned char v) {
+  opt->rep.allow_write_stall = v;
+}
+
 crocksdb_cache_t* crocksdb_cache_create_lru(size_t capacity,
   int num_shard_bits, unsigned char strict_capacity_limit, double high_pri_pool_ratio) {
   crocksdb_cache_t* c = new crocksdb_cache_t;
@@ -3443,6 +3448,41 @@ void crocksdb_ingest_external_file_cf(
     files[i] = std::string(file_list[i]);
   }
   SaveError(errptr, db->rep->IngestExternalFile(handle->rep, files, opt->rep));
+}
+
+bool crocksdb_ingest_external_file_optimized(
+    crocksdb_t* db, crocksdb_column_family_handle_t* handle,
+    const char* const* file_list, const size_t list_len,
+    const crocksdb_ingestexternalfileoptions_t* opt, char** errptr) {
+  std::vector<std::string> files(list_len);
+  for (size_t i = 0; i < list_len; ++i) {
+    files[i] = std::string(file_list[i]);
+  }
+  bool has_flush = false;
+  // If the file being ingested is overlapped with the memtable, it
+  // will block writes and wait for flushing, which can cause high
+  // write latency. So we set `allow_blocking_flush = false`.
+  auto ingest_opts = opt->rep;
+  ingest_opts.allow_blocking_flush = false;
+  auto s = db->rep->IngestExternalFile(handle->rep, files, ingest_opts);
+  if (s.IsInvalidArgument()) {
+    // When `allow_blocking_flush = false` and the file being ingested
+    // is overlapped with the memtable, `IngestExternalFile` returns
+    // an invalid argument error. Then we can try to flush the
+    // memtable outside without blocking writes. We also set
+    // `allow_write_stall = false` to prevent the flush from
+    // triggering write stall.
+    has_flush = true;
+    FlushOptions flush_opts;
+    flush_opts.allow_write_stall = false;
+    db->rep->Flush(flush_opts, handle->rep);
+  }
+  if (!s.ok()) {
+    // The above steps are just best effort optimization, if something
+    // goes wrong, we still want to ingest the file in a normal way.
+    SaveError(errptr, db->rep->IngestExternalFile(handle->rep, files, opt->rep));
+  }
+  return has_flush;
 }
 
 crocksdb_slicetransform_t* crocksdb_slicetransform_create(

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -3465,10 +3465,13 @@ bool crocksdb_ingest_external_file_optimized(
   auto ingest_opts = opt->rep;
   ingest_opts.allow_blocking_flush = false;
   auto s = db->rep->IngestExternalFile(handle->rep, files, ingest_opts);
-  if (s.IsInvalidArgument()) {
+  if (s.IsInvalidArgument() &&
+      s.ToString().find("External file requires flush") != std::string::npos) {
     // When `allow_blocking_flush = false` and the file being ingested
     // is overlapped with the memtable, `IngestExternalFile` returns
-    // an invalid argument error. Then we can try to flush the
+    // an invalid argument error. It is a bit hack to search for the
+    // specific error message here but don't worry, the unit test
+    // ensures that we get this right. Then we can try to flush the
     // memtable outside without blocking writes. We also set
     // `allow_write_stall = false` to prevent the flush from
     // triggering write stall.

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1292,6 +1292,8 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_flushoptions_destroy(
     crocksdb_flushoptions_t*);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_flushoptions_set_wait(
     crocksdb_flushoptions_t*, unsigned char);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_flushoptions_set_allow_write_stall(
+    crocksdb_flushoptions_t*, unsigned char);
 
 /* Cache */
 
@@ -1402,6 +1404,10 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_ingest_external_file(
     crocksdb_t* db, const char* const* file_list, const size_t list_len,
     const crocksdb_ingestexternalfileoptions_t* opt, char** errptr);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_ingest_external_file_cf(
+    crocksdb_t* db, crocksdb_column_family_handle_t* handle,
+    const char* const* file_list, const size_t list_len,
+    const crocksdb_ingestexternalfileoptions_t* opt, char** errptr);
+extern C_ROCKSDB_LIBRARY_API bool crocksdb_ingest_external_file_optimized(
     crocksdb_t* db, crocksdb_column_family_handle_t* handle,
     const char* const* file_list, const size_t list_len,
     const crocksdb_ingestexternalfileoptions_t* opt, char** errptr);

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -913,6 +913,7 @@ extern "C" {
     pub fn crocksdb_flushoptions_create() -> *mut DBFlushOptions;
     pub fn crocksdb_flushoptions_destroy(opt: *mut DBFlushOptions);
     pub fn crocksdb_flushoptions_set_wait(opt: *mut DBFlushOptions, whether_wait: bool);
+    pub fn crocksdb_flushoptions_set_allow_write_stall(opt: *mut DBFlushOptions, allow: bool);
 
     pub fn crocksdb_flush(
         db: *mut DBInstance,
@@ -1217,6 +1218,14 @@ extern "C" {
         opt: *const IngestExternalFileOptions,
         err: *mut *mut c_char,
     );
+    pub fn crocksdb_ingest_external_file_optimized(
+        db: *mut DBInstance,
+        handle: *const DBCFHandle,
+        file_list: *const *const c_char,
+        list_len: size_t,
+        opt: *const IngestExternalFileOptions,
+        err: *mut *mut c_char,
+    ) -> bool;
 
     // Restore Option
     pub fn crocksdb_restore_options_create() -> *mut DBRestoreOptions;

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -1490,6 +1490,12 @@ impl FlushOptions {
             crocksdb_ffi::crocksdb_flushoptions_set_wait(self.inner, wait);
         }
     }
+
+    pub fn set_allow_write_stall(&mut self, allow: bool) {
+        unsafe {
+            crocksdb_ffi::crocksdb_flushoptions_set_allow_write_stall(self.inner, allow);
+        }
+    }
 }
 
 impl Drop for FlushOptions {


### PR DESCRIPTION
Provide an optimized version of `ingest_external_file_cf`. It will first try to ingest files without blocking and fallback to a blocking ingestion if the optimization fails. See the comment for more details.