### PR TITLE
metadata: get level files count

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -37,6 +37,18 @@ impl ColumnFamilyMetaData {
         }
         levels
     }
+
+    pub fn get_level_files_count(&self, level: usize) -> usize {
+        unsafe {
+            let n = crocksdb_ffi::crocksdb_column_family_meta_data_level_count(self.inner);
+            if level >= n {
+                return 0;
+            }
+            let level_meta =
+                crocksdb_ffi::crocksdb_column_family_meta_data_level_data(self.inner, level);
+            return crocksdb_ffi::crocksdb_level_meta_data_file_count(level_meta);
+        }
+    }
 }
 
 impl Drop for ColumnFamilyMetaData {

--- a/tests/test_metadata.rs
+++ b/tests/test_metadata.rs
@@ -37,6 +37,8 @@ fn test_metadata() {
     }
 
     let cf_meta = db.get_column_family_meta_data(cf_handle);
+    let level0_files_count = cf_meta.get_level_files_count(0);
+    assert_eq!(level0_files_count, 5);
     let cf_levels = cf_meta.get_levels();
     assert_eq!(cf_levels.len(), 7);
     for (i, cf_level) in cf_levels.iter().enumerate() {


### PR DESCRIPTION
Add an API to get the files count for a specified level. This API will be used before TiKV apply snapshot, so we can check if it will trigger RocksDB stalling after ingest sst file to level0.