### PR TITLE
metadata: fix lifetime

### DIFF
--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -2454,8 +2454,7 @@ mod test {
                 db1.put(b"k2", b"v2").unwrap();
                 db1.flush(true).unwrap();
                 db1.compact_range(None, None);
-            })
-            .unwrap();
+            }).unwrap();
         // Wait until all currently running background processes finish.
         db.pause_bg_work();
         assert_eq!(

--- a/tests/test_compact_range.rs
+++ b/tests/test_compact_range.rs
@@ -101,35 +101,24 @@ fn test_compact_range_bottommost_level_compaction() {
     compact_opts.set_target_level(bottommost_level);
     db.compact_range_cf_opt(cf_handle, &compact_opts, None, None);
 
-    let bottommost_files = db
-        .get_column_family_meta_data(cf_handle)
-        .get_levels()
-        .last()
-        .unwrap()
-        .get_files();
+    let metadata = db.get_column_family_meta_data(cf_handle);
+    let bottommost_files = metadata.get_levels().last().unwrap().get_files();
     assert_eq!(bottommost_files.len(), 1);
     let bottommost_filename = bottommost_files[0].get_name();
 
     // Skip bottommost level compaction
     compact_opts.set_bottommost_level_compaction(DBBottommostLevelCompaction::Skip);
     db.compact_range_cf_opt(cf_handle, &compact_opts, None, None);
-    let bottommost_files = db
-        .get_column_family_meta_data(cf_handle)
-        .get_levels()
-        .last()
-        .unwrap()
-        .get_files();
+    let metadata = db.get_column_family_meta_data(cf_handle);
+    let bottommost_files = metadata.get_levels().last().unwrap().get_files();
     assert_eq!(bottommost_files.len(), 1);
     assert_eq!(bottommost_filename, bottommost_files[0].get_name());
+
     // Force bottommost level compaction
     compact_opts.set_bottommost_level_compaction(DBBottommostLevelCompaction::Force);
     db.compact_range_cf_opt(cf_handle, &compact_opts, None, None);
-    let bottommost_files = db
-        .get_column_family_meta_data(cf_handle)
-        .get_levels()
-        .last()
-        .unwrap()
-        .get_files();
+    let metadata = db.get_column_family_meta_data(cf_handle);
+    let bottommost_files = metadata.get_levels().last().unwrap().get_files();
     assert_eq!(bottommost_files.len(), 1);
     assert_ne!(bottommost_filename, bottommost_files[0].get_name());
 }

--- a/tests/test_compaction_filter.rs
+++ b/tests/test_compaction_filter.rs
@@ -52,8 +52,7 @@ fn test_compaction_filter() {
                 drop_called: drop_called.clone(),
                 filtered_kvs: filtered_kvs.clone(),
             }),
-        )
-        .unwrap();
+        ).unwrap();
     let mut opts = DBOptions::new();
     opts.create_if_missing(true);
     let db = DB::open_cf(
@@ -92,8 +91,7 @@ fn test_compaction_filter() {
                 drop_called: drop_called.clone(),
                 filtered_kvs: filtered_kvs.clone(),
             }),
-        )
-        .unwrap();
+        ).unwrap();
     assert!(drop_called.load(Ordering::Relaxed));
     drop_called.store(false, Ordering::Relaxed);
     {

--- a/tests/test_delete_range.rs
+++ b/tests/test_delete_range.rs
@@ -640,8 +640,7 @@ fn test_delete_range_prefix_bloom_case_1() {
         .set_prefix_extractor(
             "FixedSuffixSliceTransform",
             Box::new(FixedSuffixSliceTransform::new(3)),
-        )
-        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+        ).unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
@@ -715,8 +714,7 @@ fn test_delete_range_prefix_bloom_case_2() {
         .set_prefix_extractor(
             "FixedSuffixSliceTransform",
             Box::new(FixedSuffixSliceTransform::new(3)),
-        )
-        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+        ).unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
@@ -771,8 +769,7 @@ fn test_delete_range_prefix_bloom_case_2() {
         .set_prefix_extractor(
             "FixedSuffixSliceTransform",
             Box::new(FixedSuffixSliceTransform::new(3)),
-        )
-        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+        ).unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
@@ -808,8 +805,7 @@ fn test_delete_range_prefix_bloom_case_3() {
         .set_prefix_extractor(
             "FixedSuffixSliceTransform",
             Box::new(FixedSuffixSliceTransform::new(3)),
-        )
-        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+        ).unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
@@ -853,8 +849,7 @@ fn test_delete_range_prefix_bloom_case_3() {
         .set_prefix_extractor(
             "FixedSuffixSliceTransform",
             Box::new(FixedSuffixSliceTransform::new(3)),
-        )
-        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+        ).unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
@@ -904,8 +899,7 @@ fn test_delete_range_prefix_bloom_case_4() {
         .set_prefix_extractor(
             "FixedSuffixSliceTransform",
             Box::new(FixedSuffixSliceTransform::new(3)),
-        )
-        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+        ).unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
@@ -949,8 +943,7 @@ fn test_delete_range_prefix_bloom_case_4() {
         .set_prefix_extractor(
             "FixedSuffixSliceTransform",
             Box::new(FixedSuffixSliceTransform::new(3)),
-        )
-        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+        ).unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
@@ -1001,8 +994,7 @@ fn test_delete_range_prefix_bloom_case_5() {
         .set_prefix_extractor(
             "FixedSuffixSliceTransform",
             Box::new(FixedSuffixSliceTransform::new(3)),
-        )
-        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+        ).unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
@@ -1044,8 +1036,7 @@ fn test_delete_range_prefix_bloom_case_5() {
         .set_prefix_extractor(
             "FixedSuffixSliceTransform",
             Box::new(FixedSuffixSliceTransform::new(3)),
-        )
-        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+        ).unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let db2 = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
@@ -1093,8 +1084,7 @@ fn test_delete_range_prefix_bloom_case_6() {
         .set_prefix_extractor(
             "FixedSuffixSliceTransform",
             Box::new(FixedSuffixSliceTransform::new(3)),
-        )
-        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+        ).unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
@@ -1138,8 +1128,7 @@ fn test_delete_range_prefix_bloom_case_6() {
         .set_prefix_extractor(
             "FixedSuffixSliceTransform",
             Box::new(FixedSuffixSliceTransform::new(3)),
-        )
-        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+        ).unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let db2 = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();
@@ -1211,8 +1200,7 @@ fn test_delete_range_prefix_bloom_compact_case() {
         .set_prefix_extractor(
             "FixedSuffixSliceTransform",
             Box::new(FixedSuffixSliceTransform::new(3)),
-        )
-        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+        ).unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let cf = "default";
@@ -1256,8 +1244,7 @@ fn test_delete_range_prefix_bloom_compact_case() {
         .set_prefix_extractor(
             "FixedSuffixSliceTransform",
             Box::new(FixedSuffixSliceTransform::new(3)),
-        )
-        .unwrap_or_else(|err| panic!(format!("{:?}", err)));
+        ).unwrap_or_else(|err| panic!(format!("{:?}", err)));
     // Create prefix bloom filter for memtable.
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
     let db2 = DB::open_cf(opts, path_str, vec![(cf, cf_opts)]).unwrap();

--- a/tests/test_iterator.rs
+++ b/tests/test_iterator.rs
@@ -300,8 +300,7 @@ fn test_total_order_seek() {
         .set_prefix_extractor(
             "FixedPrefixTransform",
             Box::new(FixedPrefixTransform { prefix_len: 2 }),
-        )
-        .unwrap();
+        ).unwrap();
     // also create prefix bloom for memtable
     cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
 
@@ -387,8 +386,7 @@ fn test_fixed_suffix_seek() {
         .set_prefix_extractor(
             "FixedSuffixTransform",
             Box::new(FixedSuffixTransform { suffix_len: 2 }),
-        )
-        .unwrap();
+        ).unwrap();
 
     let db = DB::open_cf(
         opts,

--- a/tests/test_prefix_extractor.rs
+++ b/tests/test_prefix_extractor.rs
@@ -62,8 +62,7 @@ fn test_prefix_extractor_compatibility() {
             .set_prefix_extractor(
                 "FixedPrefixTransform",
                 Box::new(FixedPrefixTransform { prefix_len: 2 }),
-            )
-            .unwrap();
+            ).unwrap();
         // also create prefix bloom for memtable
         cf_opts.set_memtable_prefix_bloom_size_ratio(0.1 as f64);
         let db = DB::open_cf(

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -123,8 +123,7 @@ fn test_memtable_insert_hint_prefix_extractor() {
         .set_memtable_insert_hint_prefix_extractor(
             "FixedPrefixTransform",
             Box::new(FixedPrefixTransform { prefix_len: 2 }),
-        )
-        .unwrap();
+        ).unwrap();
     let db = DB::open_cf(
         opts,
         path.path().to_str().unwrap(),


### PR DESCRIPTION
`LevelMetaData` and `SstFileMetaData` are only valid when `ColumnFamilyMetaData` is valid, so we need to add lifetime for them.