### PR TITLE
Add on_stall_conditions_changed to EventListener

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -73,6 +73,8 @@ using rocksdb::InfoLogLevel;
 using rocksdb::FileLock;
 using rocksdb::FilterPolicy;
 using rocksdb::FlushJobInfo;
+using rocksdb::WriteStallInfo;
+using rocksdb::WriteStallCondition;
 using rocksdb::FlushOptions;
 using rocksdb::IngestExternalFileOptions;
 using rocksdb::Iterator;
@@ -189,6 +191,12 @@ struct crocksdb_histogramdata_t   { HistogramData     rep; };
 struct crocksdb_pinnableslice_t   { PinnableSlice     rep; };
 struct crocksdb_flushjobinfo_t {
   FlushJobInfo rep;
+};
+struct crocksdb_writestallcondition_t {
+  WriteStallCondition rep;
+};
+struct crocksdb_writestallinfo_t {
+  WriteStallInfo rep;
 };
 struct crocksdb_compactionjobinfo_t {
   CompactionJobInfo rep;
@@ -1739,6 +1747,14 @@ const crocksdb_table_properties_t* crocksdb_flushjobinfo_table_properties(
       &info->rep.table_properties);
 }
 
+bool crocksdb_flushjobinfo_triggered_writes_slowdown(const crocksdb_flushjobinfo_t* info) {
+  return info->rep.triggered_writes_slowdown;
+}
+
+bool crocksdb_flushjobinfo_triggered_writes_stop(const crocksdb_flushjobinfo_t* info) {
+  return info->rep.triggered_writes_stop;
+}
+
 /* CompactionJobInfo */
 
 const char* crocksdb_compactionjobinfo_cf_name(
@@ -1834,6 +1850,26 @@ crocksdb_externalfileingestioninfo_table_properties(
       &info->rep.table_properties);
 }
 
+/* External write stall info */
+extern C_ROCKSDB_LIBRARY_API const char*
+crocksdb_writestallinfo_cf_name(
+    const crocksdb_writestallinfo_t* info, size_t* size) {
+  *size = info->rep.cf_name.size();
+  return info->rep.cf_name.data();
+}
+
+const crocksdb_writestallcondition_t* crocksdb_writestallinfo_cur(
+    const crocksdb_writestallinfo_t* info) {
+  return reinterpret_cast<const crocksdb_writestallcondition_t*>(
+      &info->rep.condition.cur);
+}
+
+const crocksdb_writestallcondition_t* crocksdb_writestallinfo_prev(
+    const crocksdb_writestallinfo_t* info) {
+  return reinterpret_cast<const crocksdb_writestallcondition_t*>(
+      &info->rep.condition.prev);
+}
+
 /* event listener */
 
 struct crocksdb_eventlistener_t : public EventListener {
@@ -1845,6 +1881,7 @@ struct crocksdb_eventlistener_t : public EventListener {
                                   const crocksdb_compactionjobinfo_t*);
   void (*on_external_file_ingested)(
       void*, crocksdb_t*, const crocksdb_externalfileingestioninfo_t*);
+  void (*on_stall_conditions_changed)(void*, const crocksdb_writestallinfo_t*);
 
   virtual void OnFlushCompleted(DB* db, const FlushJobInfo& info) {
     crocksdb_t c_db = {db};
@@ -1867,6 +1904,12 @@ struct crocksdb_eventlistener_t : public EventListener {
         reinterpret_cast<const crocksdb_externalfileingestioninfo_t*>(&info));
   }
 
+  virtual void OnStallConditionsChanged(const WriteStallInfo& info) {
+    on_stall_conditions_changed(
+        state_,
+        reinterpret_cast<const crocksdb_writestallinfo_t*>(&info));
+  }
+
   virtual ~crocksdb_eventlistener_t() { destructor_(state_); }
 };
 
@@ -1874,13 +1917,15 @@ crocksdb_eventlistener_t* crocksdb_eventlistener_create(
     void* state_, void (*destructor_)(void*),
     on_flush_completed_cb on_flush_completed,
     on_compaction_completed_cb on_compaction_completed,
-    on_external_file_ingested_cb on_external_file_ingested) {
+    on_external_file_ingested_cb on_external_file_ingested,
+    on_stall_conditions_changed_cb on_stall_conditions_changed) {
   crocksdb_eventlistener_t* et = new crocksdb_eventlistener_t;
   et->state_ = state_;
   et->destructor_ = destructor_;
   et->on_flush_completed = on_flush_completed;
   et->on_compaction_completed = on_compaction_completed;
   et->on_external_file_ingested = on_external_file_ingested;
+  et->on_stall_conditions_changed = on_stall_conditions_changed;
   return et;
 }
 

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -139,6 +139,8 @@ typedef struct crocksdb_level_meta_data_t crocksdb_level_meta_data_t;
 typedef struct crocksdb_sst_file_meta_data_t crocksdb_sst_file_meta_data_t;
 typedef struct crocksdb_compaction_options_t crocksdb_compaction_options_t;
 typedef struct crocksdb_perf_context_t crocksdb_perf_context_t;
+typedef struct crocksdb_writestallinfo_t crocksdb_writestallinfo_t;
+typedef struct crocksdb_writestallcondition_t crocksdb_writestallcondition_t;
 
 typedef enum crocksdb_table_property_t {
   kDataSize = 1,
@@ -645,6 +647,10 @@ extern C_ROCKSDB_LIBRARY_API const char* crocksdb_flushjobinfo_file_path(
     const crocksdb_flushjobinfo_t*, size_t*);
 extern C_ROCKSDB_LIBRARY_API const crocksdb_table_properties_t*
 crocksdb_flushjobinfo_table_properties(const crocksdb_flushjobinfo_t*);
+extern C_ROCKSDB_LIBRARY_API bool
+crocksdb_flushjobinfo_triggered_writes_slowdown(const crocksdb_flushjobinfo_t*);
+extern C_ROCKSDB_LIBRARY_API bool
+crocksdb_flushjobinfo_triggered_writes_stop(const crocksdb_flushjobinfo_t*);
 
 /* Compaction job info */
 
@@ -698,6 +704,17 @@ extern C_ROCKSDB_LIBRARY_API const crocksdb_table_properties_t*
 crocksdb_externalfileingestioninfo_table_properties(
     const crocksdb_externalfileingestioninfo_t*);
 
+/* External write stall info */
+extern C_ROCKSDB_LIBRARY_API const char*
+crocksdb_writestallinfo_cf_name(
+    const crocksdb_writestallinfo_t*, size_t*);
+extern C_ROCKSDB_LIBRARY_API const crocksdb_writestallcondition_t*
+crocksdb_writestallinfo_cur(
+    const crocksdb_writestallinfo_t*);
+extern C_ROCKSDB_LIBRARY_API const crocksdb_writestallcondition_t*
+crocksdb_writestallinfo_prev(
+    const crocksdb_writestallinfo_t*);
+
 /* Event listener */
 
 typedef void (*on_flush_completed_cb)(void*, crocksdb_t*,
@@ -706,13 +723,15 @@ typedef void (*on_compaction_completed_cb)(void*, crocksdb_t*,
                                            const crocksdb_compactionjobinfo_t*);
 typedef void (*on_external_file_ingested_cb)(
     void*, crocksdb_t*, const crocksdb_externalfileingestioninfo_t*);
+typedef void (*on_stall_conditions_changed_cb)(void*, const crocksdb_writestallinfo_t*);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_eventlistener_t*
 crocksdb_eventlistener_create(
     void* state_, void (*destructor_)(void*),
     on_flush_completed_cb on_flush_completed,
     on_compaction_completed_cb on_compaction_completed,
-    on_external_file_ingested_cb on_external_file_ingested);
+    on_external_file_ingested_cb on_external_file_ingested,
+    on_stall_conditions_changed_cb on_stall_conditions_changed);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_eventlistener_destroy(
     crocksdb_eventlistener_t*);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_add_eventlistener(

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -68,6 +68,15 @@ pub enum DBLevelMetaData {}
 pub enum DBSstFileMetaData {}
 pub enum DBCompactionOptions {}
 pub enum DBPerfContext {}
+pub enum DBWriteStallInfo {}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(C)]
+pub enum WriteStallCondition {
+    Normal = 0,
+    Delayed = 1,
+    Stopped = 2,
+}
 
 mod generated;
 pub use generated::*;
@@ -1415,6 +1424,8 @@ extern "C" {
     pub fn crocksdb_flushjobinfo_table_properties(
         info: *const DBFlushJobInfo,
     ) -> *const DBTableProperties;
+    pub fn crocksdb_flushjobinfo_triggered_writes_slowdown(info: *const DBFlushJobInfo) -> bool;
+    pub fn crocksdb_flushjobinfo_triggered_writes_stop(info: *const DBFlushJobInfo) -> bool;
 
     pub fn crocksdb_compactionjobinfo_cf_name(
         info: *const DBCompactionJobInfo,
@@ -1464,12 +1475,23 @@ extern "C" {
         info: *const DBIngestionInfo,
     ) -> *const DBTableProperties;
 
+    pub fn crocksdb_writestallinfo_cf_name(
+        info: *const DBWriteStallInfo,
+        size: *mut size_t,
+    ) -> *const c_char;
+    pub fn crocksdb_writestallinfo_prev(
+        info: *const DBWriteStallInfo,
+    ) -> *const WriteStallCondition;
+    pub fn crocksdb_writestallinfo_cur(info: *const DBWriteStallInfo)
+        -> *const WriteStallCondition;
+
     pub fn crocksdb_eventlistener_create(
         state: *mut c_void,
         destructor: extern "C" fn(*mut c_void),
         flush: extern "C" fn(*mut c_void, *mut DBInstance, *const DBFlushJobInfo),
         compact: extern "C" fn(*mut c_void, *mut DBInstance, *const DBCompactionJobInfo),
         ingest: extern "C" fn(*mut c_void, *mut DBInstance, *const DBIngestionInfo),
+        stall_conditions: extern "C" fn(*mut c_void, *const DBWriteStallInfo),
     ) -> *mut DBEventListener;
     pub fn crocksdb_eventlistener_destroy(et: *mut DBEventListener);
     pub fn crocksdb_options_add_eventlistener(opt: *mut Options, et: *mut DBEventListener);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,11 +21,13 @@ pub extern crate librocksdb_sys;
 extern crate tempdir;
 
 pub use compaction_filter::CompactionFilter;
-pub use event_listener::{CompactionJobInfo, EventListener, FlushJobInfo, IngestionInfo};
+pub use event_listener::{
+    CompactionJobInfo, EventListener, FlushJobInfo, IngestionInfo, WriteStallInfo,
+};
 pub use librocksdb_sys::{
     self as crocksdb_ffi, new_bloom_filter, CompactionPriority, DBBottommostLevelCompaction,
     DBCompactionStyle, DBCompressionType, DBEntryType, DBInfoLogLevel, DBRecoveryMode,
-    DBStatisticsHistogramType, DBStatisticsTickerType,
+    DBStatisticsHistogramType, DBStatisticsTickerType, WriteStallCondition,
 };
 pub use merge_operator::MergeOperands;
 pub use metadata::{ColumnFamilyMetaData, LevelMetaData, SstFileMetaData};


### PR DESCRIPTION
Add `on_stall_conditions_changed` to `EventListener`, so that it could be shown in Grafana.
`triggered_writes_stop` and `triggered_writes_slowdown` are also exposed as interfaces.