### PR TITLE
Add function run_ldb_tool

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -17,6 +17,7 @@
 #include "rocksdb/env.h"
 #include "rocksdb/filter_policy.h"
 #include "rocksdb/iterator.h"
+#include "rocksdb/ldb_tool.h"
 #include "rocksdb/listener.h"
 #include "rocksdb/memtablerep.h"
 #include "rocksdb/merge_operator.h"
@@ -145,6 +146,7 @@ using rocksdb::CompactionOptions;
 using rocksdb::PerfLevel;
 using rocksdb::PerfContext;
 using rocksdb::BottommostLevelCompaction;
+using rocksdb::LDBTool;
 
 using std::shared_ptr;
 
@@ -4678,6 +4680,10 @@ uint64_t crocksdb_perf_context_env_unlock_file_nanos(crocksdb_perf_context_t* ct
 
 uint64_t crocksdb_perf_context_env_new_logger_nanos(crocksdb_perf_context_t* ctx) {
   return ctx->rep.env_new_logger_nanos;
+}
+
+void crocksdb_run_ldb_tool(int argc, char** argv) {
+  LDBTool().Run(argc, argv);
 }
 
 }  // end extern "C"

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1882,6 +1882,8 @@ extern C_ROCKSDB_LIBRARY_API uint64_t
 crocksdb_perf_context_env_unlock_file_nanos(crocksdb_perf_context_t*);
 extern C_ROCKSDB_LIBRARY_API uint64_t
 crocksdb_perf_context_env_new_logger_nanos(crocksdb_perf_context_t*);
+extern C_ROCKSDB_LIBRARY_API void
+crocksdb_run_ldb_tool(int argc, char** argv);
 
 #ifdef __cplusplus
 }  /* end extern "C" */

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1674,6 +1674,7 @@ extern "C" {
     pub fn crocksdb_perf_context_env_lock_file_nanos(ctx: *mut DBPerfContext) -> u64;
     pub fn crocksdb_perf_context_env_unlock_file_nanos(ctx: *mut DBPerfContext) -> u64;
     pub fn crocksdb_perf_context_env_new_logger_nanos(ctx: *mut DBPerfContext) -> u64;
+    pub fn crocksdb_run_ldb_tool(argc: c_int, argv: *const *const c_char);
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,9 @@ pub use merge_operator::MergeOperands;
 pub use metadata::{ColumnFamilyMetaData, LevelMetaData, SstFileMetaData};
 pub use perf_context::{get_perf_level, set_perf_level, PerfContext, PerfLevel};
 pub use rocksdb::{
-    load_latest_options, set_external_sst_file_global_seq_no, BackupEngine, CFHandle, DBIterator,
-    DBVector, Env, ExternalSstFileInfo, Kv, Range, SeekKey, SequentialFile, SstFileWriter,
-    Writable, WriteBatch, DB,
+    load_latest_options, run_ldb_tool, set_external_sst_file_global_seq_no, BackupEngine, CFHandle,
+    DBIterator, DBVector, Env, ExternalSstFileInfo, Kv, Range, SeekKey, SequentialFile,
+    SstFileWriter, Writable, WriteBatch, DB,
 };
 pub use rocksdb_options::{
     BlockBasedOptions, CColumnFamilyDescriptor, ColumnFamilyOptions, CompactOptions,

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -2204,6 +2204,20 @@ pub fn load_latest_options(
     }
 }
 
+pub fn run_ldb_tool(ldb_args: &Vec<String>) {
+    unsafe {
+        let ldb_args_cstrs: Vec<_> = ldb_args
+            .iter()
+            .map(|s| CString::new(s.as_bytes()).unwrap())
+            .collect();
+        let args: Vec<_> = ldb_args_cstrs.iter().map(|s| s.as_ptr()).collect();
+        crocksdb_ffi::crocksdb_run_ldb_tool(
+            args.len() as i32,
+            args.as_ptr() as *const *const c_char,
+        );
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
Integrate [`Ldb Tool`](https://github.com/facebook/rocksdb/wiki/Administration-and-Data-Access-Tool) [`ldb_tool.cc`](https://github.com/facebook/rocksdb/blob/master/tools/ldb_tool.cc) of RocksDB.
`run_ldb_tool` encapsulates `LDBTool::Run`, which can accept the argument from cmd line.