### PR TITLE
[DNM] Set version of libz-sys to 1.0.18

### DIFF
--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -23,7 +23,7 @@ cc = "1.0.3"
 cmake = "0.1"
 
 [dependencies.libz-sys]
-version = "1.0.25"
+version = "1.0.18"
 features = ["static"]
 
 [dependencies.bzip2-sys]


### PR DESCRIPTION
Feature `static`, which could make a staticly linked libz, only exists in version `1.0.25`.  But it depends on libc `0.2.43` which will conflict with the one in TiKV.
So, we can either revert #230 or update related packages which depends on libc in TiKV.