### PR TITLE
Support self-defined base env for encrypted env 

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -3282,15 +3282,25 @@ struct CTRBlockCipher : public BlockCipher {
   size_t block_size_;
 };
 
-crocksdb_env_t* crocksdb_default_ctr_encrypted_env_create(
+crocksdb_env_t*
+crocksdb_ctr_encrypted_env_create(crocksdb_env_t* base_env,
     const char* ciphertext, size_t ciphertext_len) {
   auto result = new crocksdb_env_t;
   result->block_cipher = new CTRBlockCipher(
       ciphertext_len, std::string(ciphertext, ciphertext_len));
   result->encryption_provoider =
       new CTREncryptionProvider(*result->block_cipher);
-  result->rep = NewEncryptedEnv(Env::Default(), result->encryption_provoider);
-  result->is_default = true;
+  result->rep = NewEncryptedEnv(base_env->rep, result->encryption_provoider);
+  result->is_default = false;
+
+  return result;
+}
+
+crocksdb_env_t* crocksdb_default_ctr_encrypted_env_create(
+    const char* ciphertext, size_t ciphertext_len) {
+  auto* default_env = crocksdb_default_env_create();
+  crocksdb_ctr_encrypted_env_create(default_env, ciphertext, ciphertext_len);
+  crocksdb_env_destroy(default_env);
 
   return result;
 }

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -3296,15 +3296,6 @@ crocksdb_ctr_encrypted_env_create(crocksdb_env_t* base_env,
   return result;
 }
 
-crocksdb_env_t* crocksdb_default_ctr_encrypted_env_create(
-    const char* ciphertext, size_t ciphertext_len) {
-  auto* default_env = crocksdb_default_env_create();
-  crocksdb_ctr_encrypted_env_create(default_env, ciphertext, ciphertext_len);
-  crocksdb_env_destroy(default_env);
-
-  return result;
-}
-
 void crocksdb_env_set_background_threads(crocksdb_env_t* env, int n) {
   env->rep->SetBackgroundThreads(n);
 }

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1312,9 +1312,6 @@ extern C_ROCKSDB_LIBRARY_API crocksdb_env_t*
 crocksdb_ctr_encrypted_env_create(crocksdb_env_t* base_env,
                                   const char* ciphertext,
                                   size_t ciphertext_len);
-extern C_ROCKSDB_LIBRARY_API crocksdb_env_t*
-crocksdb_default_ctr_encrypted_env_create(const char* ciphertext,
-                                          size_t ciphertext_len);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_env_set_background_threads(
     crocksdb_env_t* env, int n);
 extern C_ROCKSDB_LIBRARY_API void

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1309,6 +1309,10 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_cache_set_capacity(
 extern C_ROCKSDB_LIBRARY_API crocksdb_env_t* crocksdb_default_env_create();
 extern C_ROCKSDB_LIBRARY_API crocksdb_env_t* crocksdb_mem_env_create();
 extern C_ROCKSDB_LIBRARY_API crocksdb_env_t*
+crocksdb_ctr_encrypted_env_create(crocksdb_env_t* base_env,
+                                  const char* ciphertext,
+                                  size_t ciphertext_len);
+extern C_ROCKSDB_LIBRARY_API crocksdb_env_t*
 crocksdb_default_ctr_encrypted_env_create(const char* ciphertext,
                                           size_t ciphertext_len);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_env_set_background_threads(

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1128,6 +1128,11 @@ extern "C" {
     // Env
     pub fn crocksdb_default_env_create() -> *mut DBEnv;
     pub fn crocksdb_mem_env_create() -> *mut DBEnv;
+    pub fn crocksdb_ctr_encrypted_env_create(
+        base_env: *mut DBEnv,
+        ciphertext: *const c_char,
+        ciphertext_len: size_t,
+    ) -> *mut DBEnv;
     pub fn crocksdb_default_ctr_encrypted_env_create(
         ciphertext: *const c_char,
         ciphertext_len: size_t,

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1133,10 +1133,6 @@ extern "C" {
         ciphertext: *const c_char,
         ciphertext_len: size_t,
     ) -> *mut DBEnv;
-    pub fn crocksdb_default_ctr_encrypted_env_create(
-        ciphertext: *const c_char,
-        ciphertext_len: size_t,
-    ) -> *mut DBEnv;
     pub fn crocksdb_env_file_exists(env: *mut DBEnv, path: *const c_char, err: *mut *mut c_char);
     pub fn crocksdb_env_delete_file(env: *mut DBEnv, path: *const c_char, err: *mut *mut c_char);
     pub fn crocksdb_env_destroy(env: *mut DBEnv);

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -1664,6 +1664,9 @@ impl Drop for DB {
     fn drop(&mut self) {
         // SyncWAL before call close.
         if !self.readonly {
+            // DB::SyncWal requires writable file support thread safe sync, but
+            // not all types of env can create writable file that support thread
+            // safe sync. eg, MemEnv.
             self.sync_wal().unwrap_or_else(|_| {});
         }
         unsafe {

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -2080,9 +2080,9 @@ pub fn supported_compression() -> Vec<DBCompressionType> {
     }
 }
 
-#[allow(dead_code)]
 pub struct Env {
     pub inner: *mut DBEnv,
+    #[allow(dead_code)]
     base: Option<Arc<Env>>,
 }
 

--- a/tests/cases/test_encryption.rs
+++ b/tests/cases/test_encryption.rs
@@ -23,6 +23,12 @@ fn test_ctr_encrypted_env() {
         &[8, 7, 6, 5, 4, 3, 2, 1],
     ];
     for ciphertext in test_cipher_texts {
+        let base_env = Env::new_mem();
+        test_ctr_encrypted_env_impl(Arc::new(
+            Env::new_ctr_encrypted_env(&base_env, ciphertext).unwrap(),
+        ));
+    }
+    for ciphertext in test_cipher_texts {
         test_ctr_encrypted_env_impl(Arc::new(
             Env::new_default_ctr_encrypted_env(ciphertext).unwrap(),
         ));

--- a/tests/cases/test_encryption.rs
+++ b/tests/cases/test_encryption.rs
@@ -23,9 +23,9 @@ fn test_ctr_encrypted_env() {
         &[8, 7, 6, 5, 4, 3, 2, 1],
     ];
     for ciphertext in test_cipher_texts {
-        let base_env = Env::new_mem();
+        let base_env = Arc::new(Env::new_mem());
         test_ctr_encrypted_env_impl(Arc::new(
-            Env::new_ctr_encrypted_env(&base_env, ciphertext).unwrap(),
+            Env::new_ctr_encrypted_env(Arc::clone(&base_env), ciphertext).unwrap(),
         ));
     }
     for ciphertext in test_cipher_texts {


### PR DESCRIPTION
With this diff, we can pass a self-defined base env for encrypted env.