### PR TITLE
tools: pass options to ldb

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -4884,8 +4884,8 @@ uint64_t crocksdb_iostats_context_logger_nanos(crocksdb_iostats_context_t* ctx) 
   return ctx->rep.logger_nanos;
 }
 
-void crocksdb_run_ldb_tool(int argc, char** argv) {
-  LDBTool().Run(argc, argv);
+void crocksdb_run_ldb_tool(int argc, char** argv, const crocksdb_options_t* opts) {
+  LDBTool().Run(argc, argv, opts->rep);
 }
 
 /* Titan */

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1934,7 +1934,7 @@ extern C_ROCKSDB_LIBRARY_API uint64_t
 crocksdb_iostats_context_logger_nanos(crocksdb_iostats_context_t*);
 
 extern C_ROCKSDB_LIBRARY_API void
-crocksdb_run_ldb_tool(int argc, char** argv);
+crocksdb_run_ldb_tool(int argc, char** argv, const crocksdb_options_t* opts);
 
 
 /* Titan */

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1781,7 +1781,7 @@ extern "C" {
     pub fn crocksdb_iostats_context_prepare_write_nanos(ctx: *mut DBIOStatsContext) -> u64;
     pub fn crocksdb_iostats_context_logger_nanos(ctx: *mut DBIOStatsContext) -> u64;
 
-    pub fn crocksdb_run_ldb_tool(argc: c_int, argv: *const *const c_char);
+    pub fn crocksdb_run_ldb_tool(argc: c_int, argv: *const *const c_char, opts: *const Options);
 }
 
 // Titan

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -2311,7 +2311,7 @@ pub fn load_latest_options(
     }
 }
 
-pub fn run_ldb_tool(ldb_args: &Vec<String>) {
+pub fn run_ldb_tool(ldb_args: &Vec<String>, opts: &DBOptions) {
     unsafe {
         let ldb_args_cstrs: Vec<_> = ldb_args
             .iter()
@@ -2321,6 +2321,7 @@ pub fn run_ldb_tool(ldb_args: &Vec<String>) {
         crocksdb_ffi::crocksdb_run_ldb_tool(
             args.len() as i32,
             args.as_ptr() as *const *const c_char,
+            opts.inner,
         );
     }
 }


### PR DESCRIPTION
1. Update RocksDB with a bugfix and the ldb options support
2. Pass the options to run ldb tool so that we can use the environment created outside