### PR TITLE
[cherry-pick] Use libz-sys from crates.io (#230)

### DIFF
--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -23,8 +23,8 @@ cc = "1.0.3"
 cmake = "0.1"
 
 [dependencies.libz-sys]
-git = "https://github.com/busyjay/libz-sys.git"
-branch = "static-link"
+version = "1.0.25"
+features = ["static"]
 
 [dependencies.bzip2-sys]
 git = "https://github.com/alexcrichton/bzip2-rs.git"


### PR DESCRIPTION
(cherry picked from commit 5c9bcda88d9a1f55b812093394528def871739fe)