### PR TITLE
pass WriteBatch ref to db.write

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -1654,6 +1654,11 @@ void crocksdb_writebatch_set_save_point(crocksdb_writebatch_t* b) {
   b->rep.SetSavePoint();
 }
 
+void crocksdb_writebatch_pop_save_point(crocksdb_writebatch_t* b,
+                                        char** errptr) {
+  SaveError(errptr, b->rep.PopSavePoint());
+}
+
 void crocksdb_writebatch_rollback_to_save_point(crocksdb_writebatch_t* b, char** errptr) {
   SaveError(errptr, b->rep.RollbackToSavePoint());
 }

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -594,6 +594,8 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_writebatch_iterate(
 extern C_ROCKSDB_LIBRARY_API const char* crocksdb_writebatch_data(
     crocksdb_writebatch_t*, size_t* size);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_writebatch_set_save_point(crocksdb_writebatch_t*);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_writebatch_pop_save_point(
+    crocksdb_writebatch_t*, char** errptr);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_writebatch_rollback_to_save_point(crocksdb_writebatch_t*, char** errptr);
 
 /* Block based table options */

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -909,6 +909,7 @@ extern "C" {
     );
     pub fn crocksdb_writebatch_data(batch: *mut DBWriteBatch, size: *mut size_t) -> *const u8;
     pub fn crocksdb_writebatch_set_save_point(batch: *mut DBWriteBatch);
+    pub fn crocksdb_writebatch_pop_save_point(batch: *mut DBWriteBatch, err: *mut *mut c_char);
     pub fn crocksdb_writebatch_rollback_to_save_point(
         batch: *mut DBWriteBatch,
         err: *mut *mut c_char,

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -2448,7 +2448,7 @@ mod test {
         let batch = WriteBatch::with_capacity(1024);
         batch.put(b"kc1", b"v1").unwrap();
         batch.put(b"kc2", b"v2").unwrap();
-        let p = db.write(batch);
+        let p = db.write(&batch);
         assert!(p.is_ok());
         let r = db.get(b"kc1");
         assert!(r.unwrap().is_some());

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -2396,7 +2396,7 @@ mod test {
         assert_eq!(batch.count(), 1);
         assert!(!batch.is_empty());
         assert!(db.get(b"k1").unwrap().is_none());
-        let p = db.write(batch);
+        let p = db.write(&batch);
         assert!(p.is_ok());
         let r = db.get(b"k1");
         assert_eq!(r.unwrap().unwrap(), b"v1111");
@@ -2406,7 +2406,7 @@ mod test {
         let _ = batch.delete(b"k1");
         assert_eq!(batch.count(), 1);
         assert!(!batch.is_empty());
-        let p = db.write(batch);
+        let p = db.write(&batch);
         assert!(p.is_ok());
         assert!(db.get(b"k1").unwrap().is_none());
 
@@ -2431,7 +2431,7 @@ mod test {
         batch.put(b"k13", b"v13").unwrap();
         batch.rollback_to_save_point().unwrap();
         batch.rollback_to_save_point().unwrap();
-        let p = db.write(batch);
+        let p = db.write(&batch);
         assert!(p.is_ok());
         let r = db.get(b"k9");
         assert!(r.unwrap().is_none());

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -2419,9 +2419,8 @@ mod test {
 
         // test save point
         let mut batch = WriteBatch::new();
-        batch.put(b"k9", b"v9").unwrap();
         batch.set_save_point();
-        batch.pop_save_point();
+        batch.pop_save_point().unwrap();
         batch.put(b"k10", b"v10").unwrap();
         batch.set_save_point();
         batch.put(b"k11", b"v11").unwrap();
@@ -2433,8 +2432,6 @@ mod test {
         batch.rollback_to_save_point().unwrap();
         let p = db.write(&batch);
         assert!(p.is_ok());
-        let r = db.get(b"k9");
-        assert!(r.unwrap().is_none());
         let r = db.get(b"k10");
         assert_eq!(r.unwrap().unwrap(), b"v10");
         let r = db.get(b"k11");

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -659,18 +659,18 @@ impl DB {
         &self.path
     }
 
-    pub fn write_opt(&self, batch: WriteBatch, writeopts: &WriteOptions) -> Result<(), String> {
+    pub fn write_opt(&self, batch: &WriteBatch, writeopts: &WriteOptions) -> Result<(), String> {
         unsafe {
             ffi_try!(crocksdb_write(self.inner, writeopts.inner, batch.inner));
         }
         Ok(())
     }
 
-    pub fn write(&self, batch: WriteBatch) -> Result<(), String> {
+    pub fn write(&self, batch: &WriteBatch) -> Result<(), String> {
         self.write_opt(batch, &WriteOptions::new())
     }
 
-    pub fn write_without_wal(&self, batch: WriteBatch) -> Result<(), String> {
+    pub fn write_without_wal(&self, batch: &WriteBatch) -> Result<(), String> {
         let mut wo = WriteOptions::new();
         wo.disable_wal(true);
         self.write_opt(batch, &wo)

--- a/tests/cases/test_delete_range.rs
+++ b/tests/cases/test_delete_range.rs
@@ -1341,14 +1341,14 @@ fn test_delete_range() {
     prepare_data();
     let batch = WriteBatch::new();
     batch.delete_range(b"a", b"c").unwrap();
-    assert!(db.write(batch).is_ok());
+    assert!(db.write(&batch).is_ok());
     check_data();
 
     // Test `WriteBatch::delete_range_cf()`
     prepare_data();
     let batch = WriteBatch::new();
     batch.delete_range_cf(cf_handle, b"a", b"c").unwrap();
-    assert!(db.write(batch).is_ok());
+    assert!(db.write(&batch).is_ok());
     check_data();
 }
 


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>
After this change, we can reuse WriteBatch between multiple writings.