### PR TITLE
Update .gitmodules to point to pingcap/rocksdb tikv-3.0 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "rocksdb"]
 	path = librocksdb_sys/rocksdb
 	url = https://github.com/pingcap/rocksdb.git
-	branch = titan-5.15
+	branch = tikv-3.0


### PR DESCRIPTION
Update .gitmodules to point to pingcap/rocksdb tikv-3.0 branch. Also update rocksdb to include the following changes:

75133b1b6 2019-03-26 yiwu@pingcap.com     Fix SstFileReader not able to open ingested file (#5097)
7ca9eb754 2019-03-26 yiwu@pingcap.com     Fix BlockBasedTableIterator construction missing index_key_is_full parameter

Signed-off-by: Yi Wu <yiwu@pingcap.com>