### PR TITLE
*: support getting sequence number

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -1101,6 +1101,11 @@ void crocksdb_release_snapshot(
   delete snapshot;
 }
 
+uint64_t crocksdb_get_snapshot_sequence_number(
+    const crocksdb_snapshot_t* snapshot) {
+  return snapshot->rep->GetSequenceNumber();
+}
+
 char* crocksdb_property_value(
     crocksdb_t* db,
     const char* propname) {
@@ -1269,9 +1274,11 @@ void crocksdb_sync_wal(
   SaveError(errptr, db->rep->SyncWAL());
 }
 
-void crocksdb_disable_file_deletions(
-    crocksdb_t* db,
-    char** errptr) {
+uint64_t crocksdb_get_latest_sequence_number(crocksdb_t* db) {
+  return db->rep->GetLatestSequenceNumber();
+}
+
+void crocksdb_disable_file_deletions(crocksdb_t* db, char** errptr) {
   SaveError(errptr, db->rep->DisableFileDeletions());
 }
 

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -378,6 +378,8 @@ extern C_ROCKSDB_LIBRARY_API const crocksdb_snapshot_t* crocksdb_create_snapshot
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_release_snapshot(
     crocksdb_t* db, const crocksdb_snapshot_t* snapshot);
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_get_snapshot_sequence_number(const crocksdb_snapshot_t* snapshot);
 
 /* Returns NULL if property name is unknown.
    Else returns a pointer to a malloc()-ed null-terminated value. */
@@ -449,6 +451,9 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_flush_wal(
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_sync_wal(
     crocksdb_t* db, char** errptr);
+
+extern C_ROCKSDB_LIBRARY_API uint64_t
+crocksdb_get_latest_sequence_number(crocksdb_t* db);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_disable_file_deletions(crocksdb_t* db,
                                                                char** errptr);

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -709,6 +709,7 @@ extern "C" {
     ) -> *mut DBIterator;
     pub fn crocksdb_create_snapshot(db: *mut DBInstance) -> *const DBSnapshot;
     pub fn crocksdb_release_snapshot(db: *mut DBInstance, snapshot: *const DBSnapshot);
+    pub fn crocksdb_get_snapshot_sequence_number(snapshot: *const DBSnapshot) -> u64;
 
     pub fn crocksdb_delete(
         db: *mut DBInstance,
@@ -1002,6 +1003,8 @@ extern "C" {
     );
     pub fn crocksdb_flush_wal(db: *mut DBInstance, sync: bool, err: *mut *mut c_char);
     pub fn crocksdb_sync_wal(db: *mut DBInstance, err: *mut *mut c_char);
+
+    pub fn crocksdb_get_latest_sequence_number(db: *mut DBInstance) -> u64;
 
     pub fn crocksdb_approximate_sizes(
         db: *mut DBInstance,

--- a/src/titan.rs
+++ b/src/titan.rs
@@ -3,7 +3,6 @@ use std::ops::Deref;
 
 use crocksdb_ffi::{self, DBCompressionType, DBTitanBlobIndex, DBTitanDBOptions};
 use librocksdb_sys::ctitandb_encode_blob_index;
-use std::ffi::c_void;
 use std::ops::DerefMut;
 use std::os::raw::c_double;
 use std::os::raw::c_int;
@@ -148,7 +147,7 @@ impl TitanBlobIndex {
             ctitandb_encode_blob_index(&self.inner, &mut value, &mut value_size);
             let slice = slice::from_raw_parts(value, value_size as usize);
             let vec = slice.to_vec();
-            libc::free(value as *mut c_void);
+            libc::free(value as *mut libc::c_void);
             vec
         }
     }


### PR DESCRIPTION
I need a way to know the sequence number from DB and snapshot to check which snapshot is newer soon.

PTAL @yiwu-arbug @zhangjinpeng1987 