### PR TITLE
Use Vec parameter for ReadOptions' bound APIs.

### DIFF
--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -261,8 +261,8 @@ impl UnsafeSnap {
 
 pub struct ReadOptions {
     inner: *mut DBReadOptions,
-    lower_bound: Vec<u8>,
-    upper_bound: Vec<u8>,
+    lower_bound: Option<Vec<u8>>,
+    upper_bound: Option<Vec<u8>>,
 }
 
 impl Drop for ReadOptions {
@@ -278,8 +278,8 @@ impl Default for ReadOptions {
             assert!(!opts.is_null(), "Unable to create rocksdb read options");
             ReadOptions {
                 inner: opts,
-                lower_bound: vec![],
-                upper_bound: vec![],
+                lower_bound: None,
+                upper_bound: None,
             }
         }
     }
@@ -312,25 +312,33 @@ impl ReadOptions {
     }
 
     pub fn set_iterate_lower_bound(&mut self, key: &[u8]) {
-        self.lower_bound = Vec::from(key);
+        self.lower_bound = Some(Vec::from(key));
         unsafe {
             crocksdb_ffi::crocksdb_readoptions_set_iterate_lower_bound(
                 self.inner,
-                self.lower_bound.as_ptr(),
-                self.lower_bound.len(),
+                self.lower_bound.as_ref().unwrap().as_ptr(),
+                self.lower_bound.as_ref().unwrap().len(),
             );
         }
     }
 
+    pub fn iterate_lower_bound(&self) -> Option<&[u8]> {
+        self.lower_bound.as_ref().map(|v| v.as_slice())
+    }
+
     pub fn set_iterate_upper_bound(&mut self, key: &[u8]) {
-        self.upper_bound = Vec::from(key);
+        self.upper_bound = Some(Vec::from(key));
         unsafe {
             crocksdb_ffi::crocksdb_readoptions_set_iterate_upper_bound(
                 self.inner,
-                self.upper_bound.as_ptr(),
-                self.upper_bound.len(),
+                self.upper_bound.as_ref().unwrap().as_ptr(),
+                self.upper_bound.as_ref().unwrap().len(),
             );
         }
+    }
+
+    pub fn iterate_upper_bound(&self) -> Option<&[u8]> {
+        self.upper_bound.as_ref().map(|v| v.as_slice())
     }
 
     pub fn set_read_tier(&mut self, tier: c_int) {

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -261,8 +261,8 @@ impl UnsafeSnap {
 
 pub struct ReadOptions {
     inner: *mut DBReadOptions,
-    lower_bound: Option<Vec<u8>>,
-    upper_bound: Option<Vec<u8>>,
+    lower_bound: Vec<u8>,
+    upper_bound: Vec<u8>,
 }
 
 impl Drop for ReadOptions {
@@ -278,8 +278,8 @@ impl Default for ReadOptions {
             assert!(!opts.is_null(), "Unable to create rocksdb read options");
             ReadOptions {
                 inner: opts,
-                lower_bound: None,
-                upper_bound: None,
+                lower_bound: vec![],
+                upper_bound: vec![],
             }
         }
     }
@@ -311,34 +311,34 @@ impl ReadOptions {
         crocksdb_ffi::crocksdb_readoptions_set_snapshot(self.inner, snapshot.inner);
     }
 
-    pub fn set_iterate_lower_bound(&mut self, key: &[u8]) {
-        self.lower_bound = Some(Vec::from(key));
+    pub fn set_iterate_lower_bound(&mut self, key: Vec<u8>) {
+        self.lower_bound = key;
         unsafe {
             crocksdb_ffi::crocksdb_readoptions_set_iterate_lower_bound(
                 self.inner,
-                self.lower_bound.as_ref().unwrap().as_ptr(),
-                self.lower_bound.as_ref().unwrap().len(),
+                self.lower_bound.as_ptr(),
+                self.lower_bound.len(),
             );
         }
     }
 
-    pub fn iterate_lower_bound(&self) -> Option<&[u8]> {
-        self.lower_bound.as_ref().map(|v| v.as_slice())
+    pub fn iterate_lower_bound(&self) -> &[u8] {
+        &self.lower_bound
     }
 
-    pub fn set_iterate_upper_bound(&mut self, key: &[u8]) {
-        self.upper_bound = Some(Vec::from(key));
+    pub fn set_iterate_upper_bound(&mut self, key: Vec<u8>) {
+        self.upper_bound = key;
         unsafe {
             crocksdb_ffi::crocksdb_readoptions_set_iterate_upper_bound(
                 self.inner,
-                self.upper_bound.as_ref().unwrap().as_ptr(),
-                self.upper_bound.as_ref().unwrap().len(),
+                self.upper_bound.as_ptr(),
+                self.upper_bound.len(),
             );
         }
     }
 
-    pub fn iterate_upper_bound(&self) -> Option<&[u8]> {
-        self.upper_bound.as_ref().map(|v| v.as_slice())
+    pub fn iterate_upper_bound(&self) -> &[u8] {
+        &self.upper_bound
     }
 
     pub fn set_read_tier(&mut self, tier: c_int) {

--- a/tests/cases/test_iterator.rs
+++ b/tests/cases/test_iterator.rs
@@ -278,7 +278,9 @@ fn read_with_upper_bound() {
         db.put_opt(b"k2-0", b"c", &writeopts).unwrap();
 
         let mut readopts = ReadOptions::new();
-        readopts.set_iterate_upper_bound(b"k2");
+        let upper_bound = b"k2".to_vec();
+        readopts.set_iterate_upper_bound(upper_bound);
+        assert_eq!(readopts.iterate_upper_bound(), b"k2");
         let mut iter = db.iter_opt(readopts);
         iter.seek(SeekKey::Start);
         let vec = next_collect(&mut iter);

--- a/tests/cases/test_rocksdb_options.rs
+++ b/tests/cases/test_rocksdb_options.rs
@@ -656,8 +656,8 @@ fn test_readoptions_lower_bound() {
     db.put(b"k3", b"a").unwrap();
 
     let mut read_opts = ReadOptions::new();
-    let lower_bound = b"k2";
-    read_opts.set_iterate_lower_bound(lower_bound.as_ref());
+    let lower_bound = b"k2".to_vec();
+    read_opts.set_iterate_lower_bound(lower_bound);
     let mut iter = db.iter_opt(read_opts);
     iter.seek(SeekKey::Key(b"k3"));
     let mut count = 0;


### PR DESCRIPTION
Signed-off-by: zhangjinpeng1987 <zhangjinpeng@pingcap.com>

We will refactor TiKV IterOptions and reduce memory copy, this PR is a preparation.
