### PR TITLE
Add BlockBasedTableOptions::set_block_cache

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -94,6 +94,7 @@ using rocksdb::FlushOptions;
 using rocksdb::IngestExternalFileOptions;
 using rocksdb::Iterator;
 using rocksdb::Logger;
+using rocksdb::LRUCacheOptions;
 using rocksdb::MergeOperator;
 using rocksdb::NewBloomFilterPolicy;
 using rocksdb::NewLRUCache;
@@ -205,6 +206,9 @@ struct crocksdb_randomfile_t      { RandomAccessFile* rep; };
 struct crocksdb_writablefile_t    { WritableFile*     rep; };
 struct crocksdb_filelock_t        { FileLock*         rep; };
 struct crocksdb_logger_t          { shared_ptr<Logger>  rep; };
+struct crocksdb_lru_cache_options_t {
+  LRUCacheOptions rep;
+};
 struct crocksdb_cache_t           { shared_ptr<Cache>   rep; };
 struct crocksdb_livefiles_t       { std::vector<LiveFileMetaData> rep; };
 struct crocksdb_column_family_handle_t  { ColumnFamilyHandle* rep; };
@@ -3279,10 +3283,37 @@ void crocksdb_flushoptions_set_allow_write_stall(
   opt->rep.allow_write_stall = v;
 }
 
-crocksdb_cache_t* crocksdb_cache_create_lru(size_t capacity,
-  int num_shard_bits, unsigned char strict_capacity_limit, double high_pri_pool_ratio) {
+crocksdb_lru_cache_options_t* crocksdb_lru_cache_options_create() {
+  return new crocksdb_lru_cache_options_t;
+}
+
+void crocksdb_lru_cache_options_destroy(crocksdb_lru_cache_options_t* opt) {
+  delete opt;
+}
+
+void crocksdb_lru_cache_options_set_capacity(
+    crocksdb_lru_cache_options_t* opt, size_t capacity) {
+  opt->rep.capacity = capacity;
+}
+
+void crocksdb_lru_cache_options_set_num_shard_bits(
+    crocksdb_lru_cache_options_t* opt, int num_shard_bits) {
+  opt->rep.num_shard_bits = num_shard_bits;
+}
+
+void crocksdb_lru_cache_options_set_strict_capacity_limit(
+    crocksdb_lru_cache_options_t* opt, bool strict_capacity_limit) {
+  opt->rep.strict_capacity_limit = strict_capacity_limit;
+}
+
+void crocksdb_lru_cache_options_set_high_pri_pool_ratio(
+    crocksdb_lru_cache_options_t* opt, double high_pri_pool_ratio) {
+  opt->rep.high_pri_pool_ratio = high_pri_pool_ratio;
+}
+
+crocksdb_cache_t* crocksdb_cache_create_lru(crocksdb_lru_cache_options_t* opt) {
   crocksdb_cache_t* c = new crocksdb_cache_t;
-  c->rep = NewLRUCache(capacity, num_shard_bits, strict_capacity_limit, high_pri_pool_ratio);
+  c->rep = NewLRUCache(opt->rep);
   return c;
 }
 

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -74,6 +74,7 @@ typedef struct crocksdb_t                 crocksdb_t;
 typedef struct crocksdb_backup_engine_t   crocksdb_backup_engine_t;
 typedef struct crocksdb_backup_engine_info_t   crocksdb_backup_engine_info_t;
 typedef struct crocksdb_restore_options_t crocksdb_restore_options_t;
+typedef struct crocksdb_lru_cache_options_t crocksdb_lru_cache_options_t;
 typedef struct crocksdb_cache_t           crocksdb_cache_t;
 typedef struct crocksdb_compactionfilter_t crocksdb_compactionfilter_t;
 typedef struct crocksdb_compactionfiltercontext_t
@@ -1314,8 +1315,20 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_flushoptions_set_allow_write_stall(
 
 /* Cache */
 
+extern C_ROCKSDB_LIBRARY_API crocksdb_lru_cache_options_t*
+crocksdb_lru_cache_options_create();
+extern C_ROCKSDB_LIBRARY_API void crocksdb_lru_cache_options_destroy(
+    crocksdb_lru_cache_options_t*);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_lru_cache_options_set_capacity(
+    crocksdb_lru_cache_options_t*, size_t);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_lru_cache_options_set_num_shard_bits(
+    crocksdb_lru_cache_options_t*, int);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_lru_cache_options_set_strict_capacity_limit(
+    crocksdb_lru_cache_options_t*, bool);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_lru_cache_options_set_high_pri_pool_ratio(
+    crocksdb_lru_cache_options_t*, double);
 extern C_ROCKSDB_LIBRARY_API crocksdb_cache_t* crocksdb_cache_create_lru(
-    size_t capacity, int num_shard_bits, unsigned char strict_capacity_limit, double high_pri_pool_ratio);
+    crocksdb_lru_cache_options_t*);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_cache_destroy(crocksdb_cache_t* cache);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_cache_set_capacity(
     crocksdb_cache_t* cache, size_t capacity);

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -29,6 +29,7 @@ pub enum DBWriteOptions {}
 pub enum DBReadOptions {}
 pub enum DBMergeOperator {}
 pub enum DBBlockBasedTableOptions {}
+pub enum DBLRUCacheOptions {}
 pub enum DBCache {}
 pub enum DBFilterPolicy {}
 pub enum DBSnapshot {}
@@ -97,13 +98,8 @@ pub fn new_bloom_filter(bits: c_int) -> *mut DBFilterPolicy {
     unsafe { crocksdb_filterpolicy_create_bloom(bits) }
 }
 
-pub fn new_cache(
-    capacity: size_t,
-    shard_bits: c_int,
-    capacity_limit: c_uchar,
-    pri_ratio: c_double,
-) -> *mut DBCache {
-    unsafe { crocksdb_cache_create_lru(capacity, shard_bits, capacity_limit, pri_ratio) }
+pub fn new_lru_cache(opt: *mut DBLRUCacheOptions) -> *mut DBCache {
+    unsafe { crocksdb_cache_create_lru(opt) }
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -328,13 +324,20 @@ extern "C" {
     pub fn crocksdb_options_from_column_family_descriptor(
         cf_descs: *const ColumnFamilyDescriptor,
     ) -> *mut Options;
-    pub fn crocksdb_cache_create_lru(
-        capacity: size_t,
-        shard_bits: c_int,
-        capacity_limit: c_uchar,
-        pri_ratio: c_double,
-    ) -> *mut DBCache;
+
+    // Cache
+    pub fn crocksdb_lru_cache_options_create() -> *mut DBLRUCacheOptions;
+    pub fn crocksdb_lru_cache_options_destroy(opt: *mut DBLRUCacheOptions);
+    pub fn crocksdb_lru_cache_options_set_capacity(opt: *mut DBLRUCacheOptions, capacity: size_t);
+    pub fn crocksdb_lru_cache_options_set_num_shard_bits(
+        opt: *mut DBLRUCacheOptions, num_shard_bits: c_int);
+    pub fn crocksdb_lru_cache_options_set_strict_capacity_limit(
+        opt: *mut DBLRUCacheOptions, strict_capacity_limit: bool);
+    pub fn crocksdb_lru_cache_options_set_high_pri_pool_ratio(
+        opt: *mut DBLRUCacheOptions, high_pri_pool_ratio: c_double);
+    pub fn crocksdb_cache_create_lru(opt: *mut DBLRUCacheOptions) -> *mut DBCache;
     pub fn crocksdb_cache_destroy(cache: *mut DBCache);
+
     pub fn crocksdb_block_based_options_create() -> *mut DBBlockBasedTableOptions;
     pub fn crocksdb_block_based_options_destroy(opts: *mut DBBlockBasedTableOptions);
     pub fn crocksdb_block_based_options_set_block_size(

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -330,11 +330,17 @@ extern "C" {
     pub fn crocksdb_lru_cache_options_destroy(opt: *mut DBLRUCacheOptions);
     pub fn crocksdb_lru_cache_options_set_capacity(opt: *mut DBLRUCacheOptions, capacity: size_t);
     pub fn crocksdb_lru_cache_options_set_num_shard_bits(
-        opt: *mut DBLRUCacheOptions, num_shard_bits: c_int);
+        opt: *mut DBLRUCacheOptions,
+        num_shard_bits: c_int,
+    );
     pub fn crocksdb_lru_cache_options_set_strict_capacity_limit(
-        opt: *mut DBLRUCacheOptions, strict_capacity_limit: bool);
+        opt: *mut DBLRUCacheOptions,
+        strict_capacity_limit: bool,
+    );
     pub fn crocksdb_lru_cache_options_set_high_pri_pool_ratio(
-        opt: *mut DBLRUCacheOptions, high_pri_pool_ratio: c_double);
+        opt: *mut DBLRUCacheOptions,
+        high_pri_pool_ratio: c_double,
+    );
     pub fn crocksdb_cache_create_lru(opt: *mut DBLRUCacheOptions) -> *mut DBCache;
     pub fn crocksdb_cache_destroy(cache: *mut DBCache);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,13 +35,14 @@ pub use metadata::{ColumnFamilyMetaData, LevelMetaData, SstFileMetaData};
 pub use perf_context::{get_perf_level, set_perf_level, IOStatsContext, PerfContext, PerfLevel};
 pub use rocksdb::{
     load_latest_options, run_ldb_tool, set_external_sst_file_global_seq_no, BackupEngine, CFHandle,
-    DBIterator, DBVector, Env, ExternalSstFileInfo, Kv, Range, SeekKey, SequentialFile,
+    Cache, DBIterator, DBVector, Env, ExternalSstFileInfo, Kv, Range, SeekKey, SequentialFile,
     SstFileWriter, Writable, WriteBatch, DB,
 };
 pub use rocksdb_options::{
     BlockBasedOptions, CColumnFamilyDescriptor, ColumnFamilyOptions, CompactOptions,
     CompactionOptions, DBOptions, EnvOptions, FifoCompactionOptions, HistogramData,
-    IngestExternalFileOptions, RateLimiter, ReadOptions, RestoreOptions, WriteOptions,
+    IngestExternalFileOptions, LRUCacheOptions, RateLimiter, ReadOptions, RestoreOptions,
+    WriteOptions,
 };
 pub use slice_transform::SliceTransform;
 pub use table_filter::TableFilter;

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -13,15 +13,17 @@
 // limitations under the License.
 
 use crocksdb_ffi::{
-    self, DBBackupEngine, DBCFHandle, DBCompressionType, DBEnv, DBInstance, DBPinnableSlice,
-    DBSequentialFile, DBStatisticsHistogramType, DBStatisticsTickerType, DBWriteBatch,
+    self, DBBackupEngine, DBCFHandle, DBCache, DBCompressionType, DBEnv, DBInstance,
+    DBPinnableSlice, DBSequentialFile, DBStatisticsHistogramType, DBStatisticsTickerType,
+    DBWriteBatch,
 };
 use libc::{self, c_char, c_int, c_void, size_t};
 use metadata::ColumnFamilyMetaData;
 use rocksdb_options::{
     CColumnFamilyDescriptor, ColumnFamilyDescriptor, ColumnFamilyOptions, CompactOptions,
     CompactionOptions, DBOptions, EnvOptions, FlushOptions, HistogramData,
-    IngestExternalFileOptions, ReadOptions, RestoreOptions, UnsafeSnap, WriteOptions,
+    IngestExternalFileOptions, LRUCacheOptions, ReadOptions, RestoreOptions, UnsafeSnap,
+    WriteOptions,
 };
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
@@ -2284,6 +2286,26 @@ impl Drop for SequentialFile {
     fn drop(&mut self) {
         unsafe {
             crocksdb_ffi::crocksdb_sequential_file_destroy(self.inner);
+        }
+    }
+}
+
+pub struct Cache {
+    pub inner: *mut DBCache,
+}
+
+impl Cache {
+    pub fn new_lru_cache(opt: LRUCacheOptions) -> Cache {
+        Cache {
+            inner: crocksdb_ffi::new_lru_cache(opt.inner),
+        }
+    }
+}
+
+impl Drop for Cache {
+    fn drop(&mut self) {
+        unsafe {
+            crocksdb_ffi::crocksdb_cache_destroy(self.inner);
         }
     }
 }

--- a/tests/cases/test_rocksdb_options.rs
+++ b/tests/cases/test_rocksdb_options.rs
@@ -16,8 +16,9 @@ use rocksdb::crocksdb_ffi::{
     DBStatisticsHistogramType as HistogramType, DBStatisticsTickerType as TickerType,
 };
 use rocksdb::{
-    BlockBasedOptions, ColumnFamilyOptions, CompactOptions, DBOptions, Env, FifoCompactionOptions,
-    ReadOptions, SeekKey, SliceTransform, Writable, WriteOptions, DB,
+    BlockBasedOptions, Cache, ColumnFamilyOptions, CompactOptions, DBOptions, Env,
+    FifoCompactionOptions, LRUCacheOptions, ReadOptions, SeekKey, SliceTransform, Writable,
+    WriteOptions, DB,
 };
 use std::path::Path;
 use std::sync::Arc;
@@ -284,7 +285,9 @@ fn test_set_lru_cache() {
     let mut cf_opts = ColumnFamilyOptions::new();
     opts.create_if_missing(true);
     let mut block_opts = BlockBasedOptions::new();
-    block_opts.set_lru_cache(8388608, -1, 0, 0.0);
+    let mut cache_opts = LRUCacheOptions::new();
+    cache_opts.set_capacity(8388608);
+    block_opts.set_block_cache(Cache::new_lru_cache(cache_opts));
     cf_opts.set_block_based_table_factory(&block_opts);
     DB::open_cf(opts, path.path().to_str().unwrap(), vec!["default"]).unwrap();
 }
@@ -366,7 +369,9 @@ fn test_get_block_cache_usage() {
 
     opts.create_if_missing(true);
     let mut block_opts = BlockBasedOptions::new();
-    block_opts.set_lru_cache(16 * 1024 * 1024, -1, 0, 0.0);
+    let mut cache_opts = LRUCacheOptions::new();
+    cache_opts.set_capacity(16 * 1024 * 1024);
+    block_opts.set_block_cache(Cache::new_lru_cache(cache_opts));
     cf_opts.set_block_based_table_factory(&block_opts);
     let db = DB::open_cf(
         opts,
@@ -394,7 +399,9 @@ fn test_block_cache_capacity() {
     let mut cf_opts = ColumnFamilyOptions::new();
     opts.create_if_missing(true);
     let mut block_opts = BlockBasedOptions::new();
-    block_opts.set_lru_cache(16 * 1024 * 1024, -1, 0, 0.0);
+    let mut cache_opts = LRUCacheOptions::new();
+    cache_opts.set_capacity(16 * 1024 * 1024);
+    block_opts.set_block_cache(Cache::new_lru_cache(cache_opts));
     cf_opts.set_block_based_table_factory(&block_opts);
     let db = DB::open_cf(
         opts,


### PR DESCRIPTION
Adding `BlockBasedTableOptions::set_block_cache` so we can set shared block cache instance to different column family and different DB instance.

Also adding `LRUCacheOptions` and `Cache` structs.

Signed-off-by: Yi Wu <yiwu@pingcap.com>