### PR TITLE
Pass cache as reference to BlockBasedOptions::set_block_cache

### DIFF
--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -86,7 +86,7 @@ impl BlockBasedOptions {
         }
     }
 
-    pub fn set_block_cache(&mut self, cache: Cache) {
+    pub fn set_block_cache(&mut self, cache: &Cache) {
         unsafe {
             crocksdb_ffi::crocksdb_block_based_options_set_block_cache(self.inner, cache.inner);
         }

--- a/tests/cases/test_rocksdb_options.rs
+++ b/tests/cases/test_rocksdb_options.rs
@@ -287,7 +287,7 @@ fn test_set_lru_cache() {
     let mut block_opts = BlockBasedOptions::new();
     let mut cache_opts = LRUCacheOptions::new();
     cache_opts.set_capacity(8388608);
-    block_opts.set_block_cache(Cache::new_lru_cache(cache_opts));
+    block_opts.set_block_cache(&Cache::new_lru_cache(cache_opts));
     cf_opts.set_block_based_table_factory(&block_opts);
     DB::open_cf(opts, path.path().to_str().unwrap(), vec!["default"]).unwrap();
 }
@@ -371,7 +371,7 @@ fn test_get_block_cache_usage() {
     let mut block_opts = BlockBasedOptions::new();
     let mut cache_opts = LRUCacheOptions::new();
     cache_opts.set_capacity(16 * 1024 * 1024);
-    block_opts.set_block_cache(Cache::new_lru_cache(cache_opts));
+    block_opts.set_block_cache(&Cache::new_lru_cache(cache_opts));
     cf_opts.set_block_based_table_factory(&block_opts);
     let db = DB::open_cf(
         opts,
@@ -401,7 +401,7 @@ fn test_block_cache_capacity() {
     let mut block_opts = BlockBasedOptions::new();
     let mut cache_opts = LRUCacheOptions::new();
     cache_opts.set_capacity(16 * 1024 * 1024);
-    block_opts.set_block_cache(Cache::new_lru_cache(cache_opts));
+    block_opts.set_block_cache(&Cache::new_lru_cache(cache_opts));
     cf_opts.set_block_based_table_factory(&block_opts);
     let db = DB::open_cf(
         opts,


### PR DESCRIPTION
This is to get around borrow checker for TiKV side of changes. Other APIs also pass in structs as reference.

Signed-off-by: Yi Wu <yiwu@pingcap.com>