### PR TITLE
add recycle log configuration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ exclude = [
   ".travis.yml",
   "deploy.sh",
   "tests/**/*",
+  "benches/**/*",
 ]
 
 [features]

--- a/benches/cases/bench_wal.rs
+++ b/benches/cases/bench_wal.rs
@@ -16,7 +16,7 @@ use super::tempdir::TempDir;
 
 use super::test::Bencher;
 
-fn run_bench_wal(b: &mut Bencher, name: &str, mut opts: DBOptions,  wopts: WriteOptions) {
+fn run_bench_wal(b: &mut Bencher, name: &str, mut opts: DBOptions, wopts: WriteOptions) {
     let path = TempDir::new(name).expect("");
     let path_str = path.path().to_str().unwrap();
     opts.create_if_missing(true);
@@ -65,7 +65,7 @@ fn bench_wal_without_recycle_log(b: &mut Bencher) {
 
 #[bench]
 fn bench_wal_no_sync(b: &mut Bencher) {
-    let  opts = DBOptions::new();
+    let opts = DBOptions::new();
     let mut wopts = WriteOptions::new();
     wopts.set_sync(false);
 
@@ -74,7 +74,7 @@ fn bench_wal_no_sync(b: &mut Bencher) {
 
 #[bench]
 fn bench_wal_disalbe_wal(b: &mut Bencher) {
-    let  opts = DBOptions::new();
+    let opts = DBOptions::new();
     let mut wopts = WriteOptions::new();
     wopts.disable_wal(true);
 

--- a/benches/cases/bench_wal.rs
+++ b/benches/cases/bench_wal.rs
@@ -1,0 +1,82 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use super::rocksdb::{ColumnFamilyOptions, DBOptions, WriteOptions, DB};
+use super::tempdir::TempDir;
+
+use super::test::Bencher;
+
+fn run_bench_wal(b: &mut Bencher, name: &str, mut opts: DBOptions,  wopts: WriteOptions) {
+    let path = TempDir::new(name).expect("");
+    let path_str = path.path().to_str().unwrap();
+    opts.create_if_missing(true);
+    opts.set_max_background_jobs(6);
+    opts.set_max_subcompactions(2);
+
+    let mut cf_opts = ColumnFamilyOptions::new();
+    cf_opts.set_write_buffer_size(16 * 1024);
+    cf_opts.set_max_write_buffer_number(10);
+
+    let db = DB::open_cf(opts, path_str, vec![("default", cf_opts)]).unwrap();
+
+    let value = vec![1; 1024];
+
+    let mut i = 0;
+    b.iter(|| {
+        let key = format!("key_{}", i);
+        db.put_opt(key.as_bytes(), &value, &wopts).unwrap();
+        i += 1;
+    });
+
+    drop(db);
+}
+
+fn run_bench_wal_recycle_log(b: &mut Bencher, name: &str, recycled: bool) {
+    let mut opts = DBOptions::new();
+    if recycled {
+        opts.set_recycle_log_file_num(10);
+    }
+
+    let mut wopts = WriteOptions::new();
+    wopts.set_sync(true);
+
+    run_bench_wal(b, name, opts, wopts);
+}
+
+#[bench]
+fn bench_wal_with_recycle_log(b: &mut Bencher) {
+    run_bench_wal_recycle_log(b, "_rust_rocksdb_wal_with_recycle_log", true);
+}
+
+#[bench]
+fn bench_wal_without_recycle_log(b: &mut Bencher) {
+    run_bench_wal_recycle_log(b, "_rust_rocksdb_wal_without_recycle_log", false);
+}
+
+#[bench]
+fn bench_wal_no_sync(b: &mut Bencher) {
+    let  opts = DBOptions::new();
+    let mut wopts = WriteOptions::new();
+    wopts.set_sync(false);
+
+    run_bench_wal(b, "_rust_rocksdb_wal_no_sync", opts, wopts);
+}
+
+#[bench]
+fn bench_wal_disalbe_wal(b: &mut Bencher) {
+    let  opts = DBOptions::new();
+    let mut wopts = WriteOptions::new();
+    wopts.disable_wal(true);
+
+    run_bench_wal(b, "_rust_rocksdb_wal_disable_wal", opts, wopts);
+}

--- a/benches/cases/mod.rs
+++ b/benches/cases/mod.rs
@@ -1,0 +1,9 @@
+extern crate test;
+
+extern crate byteorder;
+extern crate crc;
+extern crate rand;
+extern crate rocksdb;
+extern crate tempdir;
+
+mod bench_wal;

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -1,0 +1,17 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![feature(test)]
+extern crate test;
+
+mod cases;

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -447,6 +447,7 @@ extern "C" {
     pub fn crocksdb_options_set_log_file_time_to_roll(options: *mut Options, bytes: size_t);
     pub fn crocksdb_options_set_info_log_level(options: *mut Options, level: DBInfoLogLevel);
     pub fn crocksdb_options_set_keep_log_file_num(options: *mut Options, num: size_t);
+    pub fn crocksdb_options_set_recycle_log_file_num(options: *mut Options, num: size_t);
     pub fn crocksdb_options_set_max_manifest_file_size(options: *mut Options, bytes: u64);
     pub fn crocksdb_options_set_hash_skip_list_rep(
         options: *mut Options,

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -895,6 +895,12 @@ impl DBOptions {
         }
     }
 
+    pub fn set_recycle_log_file_num(&mut self, num: u64) {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_recycle_log_file_num(self.inner, num as size_t);
+        }
+    }
+
     pub fn set_compaction_readahead_size(&mut self, size: u64) {
         unsafe {
             crocksdb_ffi::crocksdb_options_set_compaction_readahead_size(

--- a/tests/cases/test_rocksdb_options.rs
+++ b/tests/cases/test_rocksdb_options.rs
@@ -50,6 +50,7 @@ fn test_log_file_opt() {
     opts.create_if_missing(true);
     opts.set_max_log_file_size(100 * 1024 * 1024);
     opts.set_keep_log_file_num(10);
+    opts.set_recycle_log_file_num(10);
     let db = DB::open(opts, path.path().to_str().unwrap()).unwrap();
     drop(db);
 }


### PR DESCRIPTION
See https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h#L615

Add the recycle log configuration, in my local benchmark, the result is:

```
test cases::bench_wal::bench_wal_disalbe_wal         ... bench:       8,147 ns/iter (+/- 99,123)
test cases::bench_wal::bench_wal_no_sync             ... bench:      30,064 ns/iter (+/- 22,045)
test cases::bench_wal::bench_wal_with_recycle_log    ... bench:      88,007 ns/iter (+/- 60,683)
test cases::bench_wal::bench_wal_without_recycle_log ... bench:     106,474 ns/iter (+/- 126,216)
```

In our IDC with Optane disk:

```
test cases::bench_wal::bench_wal_disalbe_wal         ... bench:       9,637 ns/iter (+/- 107,219)
test cases::bench_wal::bench_wal_no_sync             ... bench:      18,944 ns/iter (+/- 125,435)
test cases::bench_wal::bench_wal_with_recycle_log    ... bench:      47,530 ns/iter (+/- 4,463)
test cases::bench_wal::bench_wal_without_recycle_log ... bench:     123,749 ns/iter (+/- 6,305)
```

@yiwu-arbug @zhangjinpeng1987 