### PR TITLE
Update Titan

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -5105,7 +5105,7 @@ void ctitandb_options_set_sample_ratio(ctitandb_options_t* options,
 }
 
 void ctitandb_options_set_blob_run_mode(ctitandb_options_t* options,
-                                       int mode) {
+                                        int mode) {
   options->rep.blob_run_mode = static_cast<TitanBlobRunMode>(mode);
 }
 

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -170,6 +170,7 @@ using rocksdb::titandb::TitanCFOptions;
 using rocksdb::titandb::TitanDB;
 using rocksdb::titandb::TitanDBOptions;
 using rocksdb::titandb::TitanOptions;
+using rocksdb::titandb::TitanBlobRunMode;
 
 using std::shared_ptr;
 
@@ -5101,6 +5102,11 @@ void ctitandb_options_set_discardable_ratio(ctitandb_options_t* options,
 void ctitandb_options_set_sample_ratio(ctitandb_options_t* options,
                                        float ratio) {
   options->rep.sample_file_size_ratio = ratio;
+}
+
+void ctitandb_options_set_blob_run_mode(ctitandb_options_t* options,
+                                       int mode) {
+  options->rep.blob_run_mode = static_cast<TitanBlobRunMode>(mode);
 }
 
 }  // end extern "C"

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -272,6 +272,14 @@ pub enum DBRateLimiterMode {
     AllIo = 3,
 }
 
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(C)]
+pub enum DBTitanDBBlobRunMode {
+    Normal = 0,
+    ReadOnly = 1,
+    Fallback = 2,
+}
+
 pub fn error_message(ptr: *mut c_char) -> String {
     let c_str = unsafe { CStr::from_ptr(ptr) };
     let s = format!("{}", c_str.to_string_lossy());
@@ -1849,6 +1857,7 @@ extern "C" {
     pub fn ctitandb_options_set_discardable_ratio(opts: *mut DBTitanDBOptions, ratio: f64);
     pub fn ctitandb_options_set_sample_ratio(opts: *mut DBTitanDBOptions, ratio: f64);
     pub fn ctitandb_options_set_merge_small_file_threshold(opts: *mut DBTitanDBOptions, size: u64);
+    pub fn ctitandb_options_set_blob_run_mode(opts: *mut DBTitanDBOptions, t: DBTitanDBBlobRunMode);
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub use librocksdb_sys::{
     self as crocksdb_ffi, new_bloom_filter, CompactionPriority, CompactionReason,
     DBBottommostLevelCompaction, DBCompactionStyle, DBCompressionType, DBEntryType, DBInfoLogLevel,
     DBRateLimiterMode, DBRecoveryMode, DBStatisticsHistogramType, DBStatisticsTickerType,
-    WriteStallCondition,
+    DBTitanDBBlobRunMode, WriteStallCondition,
 };
 pub use merge_operator::MergeOperands;
 pub use metadata::{ColumnFamilyMetaData, LevelMetaData, SstFileMetaData};

--- a/src/titan.rs
+++ b/src/titan.rs
@@ -2,7 +2,7 @@ use std::ffi::{CStr, CString};
 use std::ops::Deref;
 
 use crocksdb_ffi::{self, DBCompressionType, DBTitanBlobIndex, DBTitanDBOptions};
-use librocksdb_sys::ctitandb_encode_blob_index;
+use librocksdb_sys::{ctitandb_encode_blob_index, DBTitanDBBlobRunMode};
 use rocksdb::Cache;
 use rocksdb_options::LRUCacheOptions;
 use std::ops::DerefMut;
@@ -115,6 +115,12 @@ impl TitanDBOptions {
     pub fn set_merge_small_file_threshold(&mut self, size: u64) {
         unsafe {
             crocksdb_ffi::ctitandb_options_set_merge_small_file_threshold(self.inner, size);
+        }
+    }
+
+    pub fn set_blob_run_mode(&mut self, t: DBTitanDBBlobRunMode) {
+        unsafe {
+            crocksdb_ffi::ctitandb_options_set_blob_run_mode(self.inner, t);
         }
     }
 }


### PR DESCRIPTION
Update mainly for changes in Titan repo about blob-run-mode and metrics.
changes include:
ec440e2  Add Titan internal stats and metrics for blob file and live value
70dc779  Add blob-run-mode for downgrading Titan
3429dec  Add thread_safety_test
27ca555  Simplify CMake script
427b348  Add ticker and histrogram metrics
e493916  change codecov comment style
151b4bf  fix test config for min-blob-size
73b2918  Add clang-format script and CI job
05a3755  Delete blob files only after destroy column handle
b552d16  Add code coverage CI
37298ba  rename version to blob_storage