### PR TITLE
Avoid build require system zlib

### DIFF
--- a/librocksdb_sys/build.rs
+++ b/librocksdb_sys/build.rs
@@ -91,9 +91,6 @@ fn build_rocksdb() -> Build {
             zlib_path
         }
     });
-    for e in env::vars() {
-        println!("{:?}", e);
-    }
     let dst = cfg
         .register_dep("Z")
         .define("WITH_ZLIB", "ON")

--- a/librocksdb_sys/build.rs
+++ b/librocksdb_sys/build.rs
@@ -83,9 +83,10 @@ fn build_rocksdb() -> Build {
     if cfg!(feature = "sse") {
         cfg.define("FORCE_SSE42", "ON");
     }
+    let zlib_dir = env::var("DEP_Z_ROOT").unwrap();
     let dst = cfg
-        .register_dep("Z")
-        .define("WITH_ZLIB", "ON")
+        .cxxflag("-DZLIB")
+        .cxxflag(format!("-I{}/include", zlib_dir))
         .register_dep("BZIP2")
         .define("WITH_BZ2", "ON")
         .register_dep("LZ4")
@@ -95,6 +96,7 @@ fn build_rocksdb() -> Build {
         .register_dep("SNAPPY")
         .define("WITH_SNAPPY", "ON")
         .build_target("rocksdb")
+        .very_verbose(true)
         .build();
     let build_dir = format!("{}/build", dst.display());
     if cfg!(target_os = "windows") {

--- a/librocksdb_sys/libtitan_sys/build.rs
+++ b/librocksdb_sys/libtitan_sys/build.rs
@@ -1,14 +1,20 @@
 extern crate cc;
 extern crate cmake;
 
+use std::env;
+
 fn main() {
+    for e in env::vars() {
+        println!("{:?}", e);
+    }
     let cur_dir = std::env::current_dir().unwrap();
+    let zlib_dir = env::var("DEP_Z_ROOT").unwrap();
     let dst = cmake::Config::new("titan")
         .define("ROCKSDB_DIR", cur_dir.join("..").join("rocksdb"))
         .define("WITH_TITAN_TESTS", "OFF")
         .define("WITH_TITAN_TOOLS", "OFF")
-        .register_dep("Z")
-        .define("WITH_ZLIB", "ON")
+        .cxxflag("-DZLIB")
+        .cxxflag(format!("-I{}/include", zlib_dir))
         .register_dep("BZIP2")
         .define("WITH_BZ2", "ON")
         .register_dep("LZ4")
@@ -18,6 +24,7 @@ fn main() {
         .register_dep("SNAPPY")
         .define("WITH_SNAPPY", "ON")
         .build_target("titan")
+        .very_verbose(true)
         .build();
     println!("cargo:rustc-link-search=native={}/build", dst.display());
     println!("cargo:rustc-link-lib=static=titan");

--- a/librocksdb_sys/libtitan_sys/build.rs
+++ b/librocksdb_sys/libtitan_sys/build.rs
@@ -37,6 +37,7 @@ fn main() {
         .register_dep("SNAPPY")
         .define("WITH_SNAPPY", "ON")
         .build_target("titan")
+        .very_verbose(true)
         .build();
     println!("cargo:rustc-link-search=native={}/build", dst.display());
     println!("cargo:rustc-link-lib=static=titan");

--- a/librocksdb_sys/libtitan_sys/build.rs
+++ b/librocksdb_sys/libtitan_sys/build.rs
@@ -4,17 +4,23 @@ extern crate cmake;
 use std::env;
 
 fn main() {
-    for e in env::vars() {
-        println!("{:?}", e);
-    }
+    // RocksDB cmake script expect libz.a being under ${DEP_Z_ROOT}/lib, but libz-sys crate put it
+    // under ${DEP_Z_ROOT}/build. Append the path to CMAKE_PREFIX_PATH to get around it.
+    env::set_var("CMAKE_PREFIX_PATH", {
+        let zlib_path = format!("{}/build", env::var("DEP_Z_ROOT").unwrap());
+        if let Ok(prefix_path) = env::var("CMAKE_PREFIX_PATH") {
+            format!("{};{}", prefix_path, zlib_path)
+        } else {
+            zlib_path
+        }
+    });
     let cur_dir = std::env::current_dir().unwrap();
-    let zlib_dir = env::var("DEP_Z_ROOT").unwrap();
     let dst = cmake::Config::new("titan")
         .define("ROCKSDB_DIR", cur_dir.join("..").join("rocksdb"))
         .define("WITH_TITAN_TESTS", "OFF")
         .define("WITH_TITAN_TOOLS", "OFF")
-        .cxxflag("-DZLIB")
-        .cxxflag(format!("-I{}/include", zlib_dir))
+        .register_dep("Z")
+        .define("WITH_ZLIB", "ON")
         .register_dep("BZIP2")
         .define("WITH_BZ2", "ON")
         .register_dep("LZ4")
@@ -24,7 +30,6 @@ fn main() {
         .register_dep("SNAPPY")
         .define("WITH_SNAPPY", "ON")
         .build_target("titan")
-        .very_verbose(true)
         .build();
     println!("cargo:rustc-link-search=native={}/build", dst.display());
     println!("cargo:rustc-link-lib=static=titan");

--- a/tests/cases/mod.rs
+++ b/tests/cases/mod.rs
@@ -7,6 +7,7 @@ extern crate tempdir;
 mod test_column_family;
 mod test_compact_range;
 mod test_compaction_filter;
+mod test_compression;
 mod test_delete_files_in_range;
 mod test_delete_range;
 mod test_encryption;

--- a/tests/cases/test_compression.rs
+++ b/tests/cases/test_compression.rs
@@ -1,0 +1,42 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocksdb::{ColumnFamilyOptions, DBCompressionType, DBOptions, DB};
+use tempdir::TempDir;
+
+#[test]
+// Make sure all compression types are supported.
+fn test_compression() {
+    let path = TempDir::new("_rust_rocksdb_test_metadata").unwrap();
+    let compression_types = [
+        DBCompressionType::Snappy,
+        DBCompressionType::Zlib,
+        DBCompressionType::Bz2,
+        DBCompressionType::Lz4,
+        DBCompressionType::Lz4hc,
+        DBCompressionType::Zstd,
+    ];
+    for compression_type in compression_types.iter() {
+        let mut opts = DBOptions::new();
+        opts.create_if_missing(true);
+        let mut cf_opts = ColumnFamilyOptions::new();
+        cf_opts.compression(*compression_type);
+        // DB open will fail if compression type is not supported.
+        DB::open_cf(
+            opts,
+            path.path().to_str().unwrap(),
+            vec![("default", cf_opts)],
+        )
+        .unwrap();
+    }
+}


### PR DESCRIPTION
`register_dep("Z")` correctly set the include path for zlib, but fail to set the path to libz.a. RocksDB cmake script expect libz.a be place under ${DEP_Z_ROOT}/lib, but libz-sys place it under ${DEP_Z_ROOT}/build. Fixed it.

Also added a test to make sure possible compression types are all linked.

Signed-off-by: Yi Wu <yiwu@pingcap.com>