### PR TITLE
Allow deprecated-copy for now

### DIFF
--- a/librocksdb_sys/libtitan_sys/build.rs
+++ b/librocksdb_sys/libtitan_sys/build.rs
@@ -18,6 +18,7 @@ fn main() {
         .register_dep("SNAPPY")
         .define("WITH_SNAPPY", "ON")
         .build_target("titan")
+        .cxxflag("-Wno-deprecated-copy")
         .build();
     println!("cargo:rustc-link-search=native={}/build", dst.display());
     println!("cargo:rustc-link-lib=static=titan");


### PR DESCRIPTION
Workaround for #295 . Only a temporary fix until https://github.com/facebook/rocksdb/pull/5426 is resolved.