### PR TITLE
Fix create_cf not passinig titan specific options to titan

### DIFF
--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1976,6 +1976,13 @@ extern C_ROCKSDB_LIBRARY_API crocksdb_t* ctitandb_open_column_families(
     const ctitandb_options_t** titan_column_family_options,
     crocksdb_column_family_handle_t** column_family_handles, char** errptr);
 
+extern C_ROCKSDB_LIBRARY_API
+crocksdb_column_family_handle_t* ctitandb_create_column_family(
+    crocksdb_t* db,
+    const ctitandb_options_t* titan_column_family_options,
+    const char* column_family_name,
+    char** errptr);
+
 /* TitanDBOptions */
 
 extern C_ROCKSDB_LIBRARY_API ctitandb_options_t* ctitandb_options_create();

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1826,6 +1826,13 @@ extern "C" {
         err: *mut *mut c_char,
     ) -> *mut DBInstance;
 
+    pub fn ctitandb_create_column_family(
+        db: *mut DBInstance,
+        titan_column_family_options: *const DBTitanDBOptions,
+        column_family_name: *const c_char,
+        err: *mut *mut c_char
+    ) -> *mut DBCFHandle;
+
     pub fn ctitandb_options_create() -> *mut DBTitanDBOptions;
     pub fn ctitandb_options_destroy(opts: *mut DBTitanDBOptions);
     pub fn ctitandb_options_copy(opts: *mut DBTitanDBOptions) -> *mut DBTitanDBOptions;

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1830,7 +1830,7 @@ extern "C" {
         db: *mut DBInstance,
         titan_column_family_options: *const DBTitanDBOptions,
         column_family_name: *const c_char,
-        err: *mut *mut c_char
+        err: *mut *mut c_char,
     ) -> *mut DBCFHandle;
 
     pub fn ctitandb_options_create() -> *mut DBTitanDBOptions;

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -771,11 +771,19 @@ impl DB {
         };
         let cname_ptr = cname.as_ptr();
         unsafe {
-            let cf_handler = ffi_try!(crocksdb_create_column_family(
-                self.inner,
-                cfd.options.inner,
-                cname_ptr
-            ));
+            let cf_handler = if !self.is_titan() {
+                ffi_try!(crocksdb_create_column_family(
+                    self.inner,
+                    cfd.options.inner,
+                    cname_ptr
+                ))
+            } else {
+                ffi_try!(ctitandb_create_column_family(
+                    self.inner,
+                    cfd.options.titan_inner,
+                    cname_ptr
+                ))
+            };
             let handle = CFHandle { inner: cf_handler };
             self._cf_opts.push(cfd.options);
             Ok(match self.cfs.entry(cfd.name.to_owned()) {


### PR DESCRIPTION
Summary:
`db.create_cf` call `crocksdb_create_column_family`, which doesn't pass titan specific options to titan. Fix it by calling `ctitandb_create_column_family` when titan is enabled.

Test Plan:
Manual test when enabled titan, tikv pass correct titan options when creating new CFs.

Will add unit test in later patch.

Signed-off-by: Yi Wu <yiwu@pingcap.com>