### PR TITLE
Fix Titan portable build

### DIFF
--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -16,8 +16,8 @@ tempdir = "0.3"
 default = []
 # portable doesn't require static link, though it's meaningless
 # when not using with static-link right now in this crate.
-portable = []
-sse = []
+portable = ["libtitan_sys/portable"]
+sse = ["libtitan_sys/portable"]
 
 [build-dependencies]
 cc = "1.0.3"

--- a/librocksdb_sys/libtitan_sys/Cargo.toml
+++ b/librocksdb_sys/libtitan_sys/Cargo.toml
@@ -7,6 +7,13 @@ links = "titan"
 [dependencies]
 libc = "0.2.11"
 
+[features]
+default = []
+# portable doesn't require static link, though it's meaningless
+# when not using with static-link right now in this crate.
+portable = []
+sse = []
+
 [build-dependencies]
 cc = "1.0.3"
 cmake = "0.1"

--- a/librocksdb_sys/libtitan_sys/build.rs
+++ b/librocksdb_sys/libtitan_sys/build.rs
@@ -3,7 +3,14 @@ extern crate cmake;
 
 fn main() {
     let cur_dir = std::env::current_dir().unwrap();
-    let dst = cmake::Config::new("titan")
+    let mut cfg = cmake::Config::new("titan");
+    if cfg!(feature = "portable") {
+        cfg.define("PORTABLE", "ON");
+    }
+    if cfg!(feature = "sse") {
+        cfg.define("FORCE_SSE42", "ON");
+    }
+    let dst = cfg
         .define("ROCKSDB_DIR", cur_dir.join("..").join("rocksdb"))
         .define("WITH_TITAN_TESTS", "OFF")
         .define("WITH_TITAN_TOOLS", "OFF")


### PR DESCRIPTION
Fix build script not passing portable flag to titan.

Tested by build with `cargo build -vv --features portable` and check actual compile command does not contain -march=native flag. e.g.
```
[libtitan_sys 0.0.1] /usr/bin/c++  -DBZIP2 -DHAVE_PCLMUL -DHAVE_SSE42 -DLZ4 -DOS_LINUX -DROCKSDB_FALLOCATE_PRESENT -DROCKSDB_LIB_IO_POSIX -DROCKSDB_MALLOC_USABLE_SIZE -DROCKSDB_PLATFORM_POSIX -DROCKSDB_PTHREAD_ADAPTIVE_MUTEX -DROCKSDB_RANGESYNC_PRESENT -DROCKSDB_SCHED_GETCPU_PRESENT -DROCKSDB_SUPPORT_THREAD_LOCAL -DSNAPPY -DZLIB -DZSTD -I/data/rust-rocksdb    /target/debug/build/snappy-sys-ff485584675450be/out/build -I/data/rust-rocksdb/target/debug/build/bzip2-sys-593753ebc763ecf6/out/include -I/data/rust-rocksdb/target/debug/build/lz4-sys-c5ffb8280e1f82b8/out/include -I/data/rust-rocksdb/target/debug/build/libz-sys-da832d3a86675e51/out/include -I/data/rust-rocksdb/target/debug/build/zstd-sys-ddb8409269514a6a/    out/include -I/data/rust-rocksdb/librocksdb_sys/libtitan_sys/../rocksdb -I/data/rust-rocksdb/librocksdb_sys/libtitan_sys/../rocksdb/include -I/data/rust-rocksdb/librocksdb_sys/libtitan_sys/titan/include -I/data/rust-rocksdb/librocksdb_sys/libtitan_sys/titan/src  -ffunction-sections -fdata-sections -fPIC -m64 -W -Wextra -Wall -Wsign-compare -Wshadow -Wno-un    used-parameter -Wno-unused-variable -Woverloaded-virtual -Wnon-virtual-dtor -Wno-missing-field-initializers -Wno-strict-aliasing -std=c++11 -Werror -fno-builtin-memcmp -g -DROCKSDB_USE_RTTI   -o CMakeFiles/titan.dir/src/blob_file_cache.cc.o -c /data/rust-rocksdb/librocksdb_sys/libtitan_sys/titan/src/blob_file_cache.cc
```

Signed-off-by: Yi Wu <yiwu@pingcap.com>