### PR TITLE
Add feature "jemalloc" to enable "WITH_JEMALLOC" on rocksdb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,10 @@ exclude = [
 
 [features]
 default = []
-valgrind = []
+jemalloc = ["librocksdb_sys/jemalloc"]
 portable = ["librocksdb_sys/portable"]
 sse = ["librocksdb_sys/sse"]
+valgrind = []
 
 [dependencies]
 libc = "0.2.11"

--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -14,6 +14,7 @@ tempdir = "0.3"
 
 [features]
 default = []
+jemalloc = []
 # portable doesn't require static link, though it's meaningless
 # when not using with static-link right now in this crate.
 portable = ["libtitan_sys/portable"]

--- a/librocksdb_sys/build.rs
+++ b/librocksdb_sys/build.rs
@@ -77,6 +77,9 @@ fn build_rocksdb() -> Build {
     }
 
     let mut cfg = Config::new("rocksdb");
+    if cfg!(feature = "jemalloc") {
+        cfg.define("WITH_JEMALLOC", "ON");
+    }
     if cfg!(feature = "portable") {
         cfg.define("PORTABLE", "ON");
     }


### PR DESCRIPTION
Adding feature "jemalloc". When enabled, rocksdb "WITH_JEMALLOC" will be enabled. This does NOT affect whether jemalloc is use or not. Mostly it only affect how rocksdb calculate block cache size: if "WITH_JEMALLOC" is on, it will use `malloc_usable_size()` (size allocated by jemalloc) to calculate size of each entry of block cache, instead of the requested size of the allocation.

Tested by running `cargo build --features jemalloc -vv` and check rocksdb compile flags from the output.

Signed-off-by: Yi Wu <yiwu@pingcap.com>