### PR TITLE
Add jemalloc-sys dependency when jemalloc is enabled

### DIFF
--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -14,7 +14,7 @@ tempdir = "0.3"
 
 [features]
 default = []
-jemalloc = []
+jemalloc = ["jemalloc-sys"]
 # portable doesn't require static link, though it's meaningless
 # when not using with static-link right now in this crate.
 portable = ["libtitan_sys/portable"]
@@ -23,6 +23,10 @@ sse = ["libtitan_sys/sse"]
 [build-dependencies]
 cc = "1.0.3"
 cmake = "0.1"
+
+[dependencies.jemalloc-sys]
+version = ">= 0.1.8"
+optional = true
 
 [dependencies.libz-sys]
 version = "1.0.25"

--- a/librocksdb_sys/build.rs
+++ b/librocksdb_sys/build.rs
@@ -78,7 +78,7 @@ fn build_rocksdb() -> Build {
 
     let mut cfg = Config::new("rocksdb");
     if cfg!(feature = "jemalloc") {
-        cfg.define("WITH_JEMALLOC", "ON");
+        cfg.register_dep("JEMALLOC").define("WITH_JEMALLOC", "ON");
     }
     if cfg!(feature = "portable") {
         cfg.define("PORTABLE", "ON");


### PR DESCRIPTION
When jemalloc feature is on, add jemalloc-sys dependency and pass its lib path to rocksdb.

Tested on ubuntu with libjemalloc-dev uninstalled.

Signed-off-by: Yi Wu <yiwu@pingcap.com>