### PR TITLE
Fix perf context test

### DIFF
--- a/src/perf_context.rs
+++ b/src/perf_context.rs
@@ -419,6 +419,7 @@ mod test {
             }
         }
 
+        set_perf_level(PerfLevel::EnableCount);
         let mut ctx = PerfContext::get();
 
         let mut iter = db.iter();


### PR DESCRIPTION
Fixing perf context test failure with `cargo test -- --test_threads=1`. The test assume default perf level is `PerfLevel::EnableCount`, which apparently will affected by other tests.

Tested by running `cargo test -- --test_threads=1`.

Closing #318 

Signed-off-by: Yi Wu <yiwu@pingcap.com>