### PR TITLE
Not to compile with gflags

### DIFF
--- a/librocksdb_sys/build.rs
+++ b/librocksdb_sys/build.rs
@@ -87,6 +87,7 @@ fn build_rocksdb() -> Build {
         cfg.define("FORCE_SSE42", "ON");
     }
     let dst = cfg
+        .define("WITH_GFLAGS", "OFF")
         .register_dep("Z")
         .define("WITH_ZLIB", "ON")
         .register_dep("BZIP2")


### PR DESCRIPTION
RocksDB cmake default to build with gflags but we actually don't depend on it. We thought ldb would depend on gflags but it actually not. Disabling it.

Tested by build tikv with the change. Tried `tikv-ctl --db=xxx scan --from=xxx --to=xxx` and it works.

Signed-off-by: Yi Wu <yiwu@pingcap.com>