### PR TITLE
Cherry-pick build and dependency fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,10 @@ exclude = [
 
 [features]
 default = []
-valgrind = []
+jemalloc = ["librocksdb_sys/jemalloc"]
 portable = ["librocksdb_sys/portable"]
 sse = ["librocksdb_sys/sse"]
+valgrind = []
 
 [dependencies]
 libc = "0.2.11"

--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -14,6 +14,7 @@ tempdir = "0.3"
 
 [features]
 default = []
+jemalloc = []
 # portable doesn't require static link, though it's meaningless
 # when not using with static-link right now in this crate.
 portable = ["libtitan_sys/portable"]

--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -14,7 +14,7 @@ tempdir = "0.3"
 
 [features]
 default = []
-jemalloc = []
+jemalloc = ["jemalloc-sys"]
 # portable doesn't require static link, though it's meaningless
 # when not using with static-link right now in this crate.
 portable = ["libtitan_sys/portable"]
@@ -23,6 +23,10 @@ sse = ["libtitan_sys/sse"]
 [build-dependencies]
 cc = "1.0.3"
 cmake = "0.1"
+
+[dependencies.jemalloc-sys]
+version = ">= 0.1.8"
+optional = true
 
 [dependencies.libz-sys]
 version = "1.0.25"

--- a/librocksdb_sys/build.rs
+++ b/librocksdb_sys/build.rs
@@ -78,7 +78,7 @@ fn build_rocksdb() -> Build {
 
     let mut cfg = Config::new("rocksdb");
     if cfg!(feature = "jemalloc") {
-        cfg.define("WITH_JEMALLOC", "ON");
+        cfg.register_dep("JEMALLOC").define("WITH_JEMALLOC", "ON");
     }
     if cfg!(feature = "portable") {
         cfg.define("PORTABLE", "ON");

--- a/librocksdb_sys/build.rs
+++ b/librocksdb_sys/build.rs
@@ -77,6 +77,9 @@ fn build_rocksdb() -> Build {
     }
 
     let mut cfg = Config::new("rocksdb");
+    if cfg!(feature = "jemalloc") {
+        cfg.define("WITH_JEMALLOC", "ON");
+    }
     if cfg!(feature = "portable") {
         cfg.define("PORTABLE", "ON");
     }

--- a/librocksdb_sys/build.rs
+++ b/librocksdb_sys/build.rs
@@ -87,6 +87,7 @@ fn build_rocksdb() -> Build {
         cfg.define("FORCE_SSE42", "ON");
     }
     let dst = cfg
+        .define("WITH_GFLAGS", "OFF")
         .register_dep("Z")
         .define("WITH_ZLIB", "ON")
         .register_dep("BZIP2")

--- a/librocksdb_sys/libtitan_sys/build.rs
+++ b/librocksdb_sys/libtitan_sys/build.rs
@@ -1,7 +1,19 @@
 extern crate cc;
 extern crate cmake;
 
+use std::env;
+
 fn main() {
+    // RocksDB cmake script expect libz.a being under ${DEP_Z_ROOT}/lib, but libz-sys crate put it
+    // under ${DEP_Z_ROOT}/build. Append the path to CMAKE_PREFIX_PATH to get around it.
+    env::set_var("CMAKE_PREFIX_PATH", {
+        let zlib_path = format!("{}/build", env::var("DEP_Z_ROOT").unwrap());
+        if let Ok(prefix_path) = env::var("CMAKE_PREFIX_PATH") {
+            format!("{};{}", prefix_path, zlib_path)
+        } else {
+            zlib_path
+        }
+    });
     let cur_dir = std::env::current_dir().unwrap();
     let mut cfg = cmake::Config::new("titan");
     if cfg!(feature = "portable") {
@@ -25,6 +37,7 @@ fn main() {
         .register_dep("SNAPPY")
         .define("WITH_SNAPPY", "ON")
         .build_target("titan")
+        .very_verbose(true)
         .build();
     println!("cargo:rustc-link-search=native={}/build", dst.display());
     println!("cargo:rustc-link-lib=static=titan");

--- a/src/perf_context.rs
+++ b/src/perf_context.rs
@@ -419,6 +419,7 @@ mod test {
             }
         }
 
+        set_perf_level(PerfLevel::EnableCount);
         let mut ctx = PerfContext::get();
 
         let mut iter = db.iter();

--- a/tests/cases/mod.rs
+++ b/tests/cases/mod.rs
@@ -7,6 +7,7 @@ extern crate tempdir;
 mod test_column_family;
 mod test_compact_range;
 mod test_compaction_filter;
+mod test_compression;
 mod test_delete_files_in_range;
 mod test_delete_range;
 mod test_encryption;

--- a/tests/cases/test_compression.rs
+++ b/tests/cases/test_compression.rs
@@ -1,0 +1,42 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rocksdb::{ColumnFamilyOptions, DBCompressionType, DBOptions, DB};
+use tempdir::TempDir;
+
+#[test]
+// Make sure all compression types are supported.
+fn test_compression() {
+    let path = TempDir::new("_rust_rocksdb_test_metadata").unwrap();
+    let compression_types = [
+        DBCompressionType::Snappy,
+        DBCompressionType::Zlib,
+        DBCompressionType::Bz2,
+        DBCompressionType::Lz4,
+        DBCompressionType::Lz4hc,
+        DBCompressionType::Zstd,
+    ];
+    for compression_type in compression_types.iter() {
+        let mut opts = DBOptions::new();
+        opts.create_if_missing(true);
+        let mut cf_opts = ColumnFamilyOptions::new();
+        cf_opts.compression(*compression_type);
+        // DB open will fail if compression type is not supported.
+        DB::open_cf(
+            opts,
+            path.path().to_str().unwrap(),
+            vec![("default", cf_opts)],
+        )
+        .unwrap();
+    }
+}


### PR DESCRIPTION
Cherry-picking the following changes that fixes zlib, jemalloc and gflags dependencies, and fixes a flaky test:
```
6ead62c 2019-07-25 yiwu@pingcap.com     Avoid build require system zlib (#303)
9246b9c 2019-07-25 hi@breeswish.org     Skip jemalloc options on specific platform (#324)
7a8dd73 2019-07-22 yiwu@pingcap.com     Add jemalloc-sys dependency when jemalloc is enabled (#320)
6f2c632 2019-07-23 yiwu@pingcap.com     Not compile with gflags (#322)
09b8032 2019-07-22 yiwu@pingcap.com     Fix perf context test (#321)
d67f38e 2019-07-21 yiwu@pingcap.com     Add jemalloc feature (#319)
```

Also update rocksdb to fix compile error with gcc9:
```
7a03c83ed 2019-07-23 psergey@askmonty.org Fix MyRocks compile warnings-treated-as-errors on Fedora 30, gcc 9.1.1 (#5553)
```