### PR TITLE
Adding jemalloc no-dump allocator option for lru-cache

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -3331,6 +3331,14 @@ void crocksdb_lru_cache_options_set_high_pri_pool_ratio(
   opt->rep.high_pri_pool_ratio = high_pri_pool_ratio;
 }
 
+void crocksdb_lru_cache_options_set_no_dump_allocator(
+    crocksdb_lru_cache_options_t* opt) {
+    std::shared_ptr<rocksdb::MemoryAllocator> allocator;
+    rocksdb::JemallocAllocatorOptions options;
+    rocksdb::NewJemallocNodumpAllocator(options, &allocator);
+    opt->rep.memory_allocator = allocator;
+}
+
 crocksdb_cache_t* crocksdb_cache_create_lru(crocksdb_lru_cache_options_t* opt) {
   crocksdb_cache_t* c = new crocksdb_cache_t;
   c->rep = NewLRUCache(opt->rep);

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1336,6 +1336,8 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_lru_cache_options_set_strict_capacity
     crocksdb_lru_cache_options_t*, bool);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_lru_cache_options_set_high_pri_pool_ratio(
     crocksdb_lru_cache_options_t*, double);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_lru_cache_options_set_no_dump_allocator(
+    crocksdb_lru_cache_options_t*);
 extern C_ROCKSDB_LIBRARY_API crocksdb_cache_t* crocksdb_cache_create_lru(
     crocksdb_lru_cache_options_t*);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_cache_destroy(crocksdb_cache_t* cache);

--- a/librocksdb_sys/libtitan_sys/build.rs
+++ b/librocksdb_sys/libtitan_sys/build.rs
@@ -36,6 +36,7 @@ fn main() {
         .define("WITH_ZSTD", "ON")
         .register_dep("SNAPPY")
         .define("WITH_SNAPPY", "ON")
+        .define("WITH_JEMALLOC", "ON")
         .build_target("titan")
         .very_verbose(true)
         .build();

--- a/librocksdb_sys/libtitan_sys/build.rs
+++ b/librocksdb_sys/libtitan_sys/build.rs
@@ -36,7 +36,6 @@ fn main() {
         .define("WITH_ZSTD", "ON")
         .register_dep("SNAPPY")
         .define("WITH_SNAPPY", "ON")
-        .define("WITH_JEMALLOC", "ON")
         .build_target("titan")
         .very_verbose(true)
         .build();

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -359,6 +359,7 @@ extern "C" {
         opt: *mut DBLRUCacheOptions,
         high_pri_pool_ratio: c_double,
     );
+    pub fn crocksdb_lru_cache_options_set_no_dump_allocator(opt: *mut DBLRUCacheOptions);
     pub fn crocksdb_cache_create_lru(opt: *mut DBLRUCacheOptions) -> *mut DBCache;
     pub fn crocksdb_cache_destroy(cache: *mut DBCache);
 

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -1877,6 +1877,12 @@ impl LRUCacheOptions {
             );
         }
     }
+
+    pub fn set_no_dump_allocator(&mut self) {
+        unsafe {
+            crocksdb_ffi::crocksdb_lru_cache_options_set_no_dump_allocator(self.inner);
+        }
+    }
 }
 
 impl Drop for LRUCacheOptions {

--- a/tests/cases/test_rocksdb_options.rs
+++ b/tests/cases/test_rocksdb_options.rs
@@ -319,6 +319,21 @@ fn test_set_lru_cache() {
 }
 
 #[test]
+fn test_set_no_dump_lru_cache() {
+    let path = TempDir::new("_rust_rocksdb_set_set_no_dump_lru_cache").expect("");
+    let mut opts = DBOptions::new();
+    let mut cf_opts = ColumnFamilyOptions::new();
+    opts.create_if_missing(true);
+    let mut block_opts = BlockBasedOptions::new();
+    let mut cache_opts = LRUCacheOptions::new();
+    cache_opts.set_no_dump_allocator();
+    cache_opts.set_capacity(8388608);
+    block_opts.set_block_cache(&Cache::new_lru_cache(cache_opts));
+    cf_opts.set_block_based_table_factory(&block_opts);
+    DB::open_cf(opts, path.path().to_str().unwrap(), vec!["default"]).unwrap();
+}
+
+#[test]
 fn test_set_cache_index_and_filter_blocks_with_high_priority() {
     let path = TempDir::new("_rust_rocksdb_set_cache_and_index_with_high_priority").expect("");
     let mut opts = DBOptions::new();


### PR DESCRIPTION
Adding LRUCacheOptions::set_no_dump_allocator, so we can use JemallocNoDumpAllocator of rocksdb to exclude some LRU Cache, like block cache, from core dump.