### PR TITLE
Adding jemalloc-nodump-allocator option for lru-cache

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -3331,6 +3331,14 @@ void crocksdb_lru_cache_options_set_high_pri_pool_ratio(
   opt->rep.high_pri_pool_ratio = high_pri_pool_ratio;
 }
 
+void crocksdb_lru_cache_options_set_no_dump_allocator(
+    crocksdb_lru_cache_options_t* opt) {
+    std::shared_ptr<rocksdb::MemoryAllocator> allocator;
+    rocksdb::JemallocAllocatorOptions options;
+    rocksdb::NewJemallocNodumpAllocator(options, &allocator);
+    opt->rep.memory_allocator = allocator;
+}
+
 crocksdb_cache_t* crocksdb_cache_create_lru(crocksdb_lru_cache_options_t* opt) {
   crocksdb_cache_t* c = new crocksdb_cache_t;
   c->rep = NewLRUCache(opt->rep);

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -3306,10 +3306,10 @@ void crocksdb_flushoptions_set_allow_write_stall(
   opt->rep.allow_write_stall = v;
 }
 
-crocksdb_memory_allocator_t* crocksdb_jemalloc_nodump_allocator_create() {
+crocksdb_memory_allocator_t* crocksdb_jemalloc_nodump_allocator_create(char** errptr) {
   crocksdb_memory_allocator_t* allocator = new crocksdb_memory_allocator_t;
   rocksdb::JemallocAllocatorOptions options;
-  rocksdb::NewJemallocNodumpAllocator(options, &allocator->rep);
+  SaveError(errptr, rocksdb::NewJemallocNodumpAllocator(options, &allocator->rep));
   return allocator;
 }
 

--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -173,6 +173,8 @@ using rocksdb::titandb::TitanOptions;
 using rocksdb::titandb::TitanReadOptions;
 using rocksdb::titandb::TitanBlobRunMode;
 
+using rocksdb::MemoryAllocator;
+
 using std::shared_ptr;
 
 extern "C" {
@@ -212,6 +214,7 @@ struct crocksdb_lru_cache_options_t {
   LRUCacheOptions rep;
 };
 struct crocksdb_cache_t           { shared_ptr<Cache>   rep; };
+struct crocksdb_memory_allocator_t { shared_ptr<MemoryAllocator> rep; };
 struct crocksdb_livefiles_t       { std::vector<LiveFileMetaData> rep; };
 struct crocksdb_column_family_handle_t  { ColumnFamilyHandle* rep; };
 struct crocksdb_envoptions_t      { EnvOptions        rep; };
@@ -3303,6 +3306,17 @@ void crocksdb_flushoptions_set_allow_write_stall(
   opt->rep.allow_write_stall = v;
 }
 
+crocksdb_memory_allocator_t* crocksdb_jemalloc_nodump_allocator_create() {
+  crocksdb_memory_allocator_t* allocator = new crocksdb_memory_allocator_t;
+  rocksdb::JemallocAllocatorOptions options;
+  rocksdb::NewJemallocNodumpAllocator(options, &allocator->rep);
+  return allocator;
+}
+
+void crocksdb_memory_allocator_destroy(crocksdb_memory_allocator_t* allocator) {
+  delete allocator;
+}
+
 crocksdb_lru_cache_options_t* crocksdb_lru_cache_options_create() {
   return new crocksdb_lru_cache_options_t;
 }
@@ -3331,12 +3345,9 @@ void crocksdb_lru_cache_options_set_high_pri_pool_ratio(
   opt->rep.high_pri_pool_ratio = high_pri_pool_ratio;
 }
 
-void crocksdb_lru_cache_options_set_no_dump_allocator(
-    crocksdb_lru_cache_options_t* opt) {
-    std::shared_ptr<rocksdb::MemoryAllocator> allocator;
-    rocksdb::JemallocAllocatorOptions options;
-    rocksdb::NewJemallocNodumpAllocator(options, &allocator);
-    opt->rep.memory_allocator = allocator;
+void crocksdb_lru_cache_options_set_memory_allocator(
+    crocksdb_lru_cache_options_t* opt, crocksdb_memory_allocator_t* allocator) {
+    opt->rep.memory_allocator = allocator->rep;
 }
 
 crocksdb_cache_t* crocksdb_cache_create_lru(crocksdb_lru_cache_options_t* opt) {
@@ -5137,7 +5148,7 @@ void ctitandb_options_set_max_background_gc(ctitandb_options_t* options,
   options->rep.max_background_gc = size;
 }
 
-void ctitandb_options_set_purge_obsolete_files_period(ctitandb_options_t* options, 
+void ctitandb_options_set_purge_obsolete_files_period(ctitandb_options_t* options,
                                                       unsigned int period) {
   options->rep.purge_obsolete_files_period = period;
 }
@@ -5169,12 +5180,12 @@ struct ctitandb_readoptions_t {
   TitanReadOptions rep;
 };
 
-ctitandb_readoptions_t* ctitandb_readoptions_create() { 
-  return new ctitandb_readoptions_t; 
+ctitandb_readoptions_t* ctitandb_readoptions_create() {
+  return new ctitandb_readoptions_t;
 }
 
-void ctitandb_readoptions_destroy(ctitandb_readoptions_t* opts) { 
-  delete opts; 
+void ctitandb_readoptions_destroy(ctitandb_readoptions_t* opts) {
+  delete opts;
 }
 
 bool ctitandb_readoptions_key_only(ctitandb_readoptions_t* opts) {

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -76,6 +76,7 @@ typedef struct crocksdb_backup_engine_info_t   crocksdb_backup_engine_info_t;
 typedef struct crocksdb_restore_options_t crocksdb_restore_options_t;
 typedef struct crocksdb_lru_cache_options_t crocksdb_lru_cache_options_t;
 typedef struct crocksdb_cache_t           crocksdb_cache_t;
+typedef struct crocksdb_memory_allocator_t crocksdb_memory_allocator_t;
 typedef struct crocksdb_compactionfilter_t crocksdb_compactionfilter_t;
 typedef struct crocksdb_compactionfiltercontext_t
     crocksdb_compactionfiltercontext_t;
@@ -1322,6 +1323,12 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_flushoptions_set_wait(
 extern C_ROCKSDB_LIBRARY_API void crocksdb_flushoptions_set_allow_write_stall(
     crocksdb_flushoptions_t*, unsigned char);
 
+/* Memory allocator */
+
+extern C_ROCKSDB_LIBRARY_API crocksdb_memory_allocator_t*
+crocksdb_jemalloc_nodump_allocator_create();
+extern C_ROCKSDB_LIBRARY_API void crocksdb_memory_allocator_destroy(crocksdb_memory_allocator_t*);
+
 /* Cache */
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_lru_cache_options_t*
@@ -1336,8 +1343,8 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_lru_cache_options_set_strict_capacity
     crocksdb_lru_cache_options_t*, bool);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_lru_cache_options_set_high_pri_pool_ratio(
     crocksdb_lru_cache_options_t*, double);
-extern C_ROCKSDB_LIBRARY_API void crocksdb_lru_cache_options_set_no_dump_allocator(
-    crocksdb_lru_cache_options_t*);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_lru_cache_options_set_memory_allocator(
+    crocksdb_lru_cache_options_t*, crocksdb_memory_allocator_t*);
 extern C_ROCKSDB_LIBRARY_API crocksdb_cache_t* crocksdb_cache_create_lru(
     crocksdb_lru_cache_options_t*);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_cache_destroy(crocksdb_cache_t* cache);

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1336,6 +1336,8 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_lru_cache_options_set_strict_capacity
     crocksdb_lru_cache_options_t*, bool);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_lru_cache_options_set_high_pri_pool_ratio(
     crocksdb_lru_cache_options_t*, double);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_lru_cache_options_set_no_dump_allocator(
+    crocksdb_lru_cache_options_t*);
 extern C_ROCKSDB_LIBRARY_API crocksdb_cache_t* crocksdb_cache_create_lru(
     crocksdb_lru_cache_options_t*);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_cache_destroy(crocksdb_cache_t* cache);

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1326,7 +1326,7 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_flushoptions_set_allow_write_stall(
 /* Memory allocator */
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_memory_allocator_t*
-crocksdb_jemalloc_nodump_allocator_create();
+crocksdb_jemalloc_nodump_allocator_create(char** errptr);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_memory_allocator_destroy(crocksdb_memory_allocator_t*);
 
 /* Cache */

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -29,6 +29,7 @@ pub enum DBWriteOptions {}
 pub enum DBReadOptions {}
 pub enum DBMergeOperator {}
 pub enum DBBlockBasedTableOptions {}
+pub enum DBMemoryAllocator {}
 pub enum DBLRUCacheOptions {}
 pub enum DBCache {}
 pub enum DBFilterPolicy {}
@@ -343,6 +344,10 @@ extern "C" {
         cf_descs: *const ColumnFamilyDescriptor,
     ) -> *mut Options;
 
+    // Memory Allocator
+    pub fn crocksdb_jemalloc_nodump_allocator_create() -> *mut DBMemoryAllocator;
+    pub fn crocksdb_memory_allocator_destroy(allocator: *mut DBMemoryAllocator);
+
     // Cache
     pub fn crocksdb_lru_cache_options_create() -> *mut DBLRUCacheOptions;
     pub fn crocksdb_lru_cache_options_destroy(opt: *mut DBLRUCacheOptions);
@@ -359,7 +364,10 @@ extern "C" {
         opt: *mut DBLRUCacheOptions,
         high_pri_pool_ratio: c_double,
     );
-    pub fn crocksdb_lru_cache_options_set_no_dump_allocator(opt: *mut DBLRUCacheOptions);
+    pub fn crocksdb_lru_cache_options_set_memory_allocator(
+        opt: *mut DBLRUCacheOptions,
+        allocator: *mut DBMemoryAllocator,
+    );
     pub fn crocksdb_cache_create_lru(opt: *mut DBLRUCacheOptions) -> *mut DBCache;
     pub fn crocksdb_cache_destroy(cache: *mut DBCache);
 

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -359,6 +359,7 @@ extern "C" {
         opt: *mut DBLRUCacheOptions,
         high_pri_pool_ratio: c_double,
     );
+    pub fn crocksdb_lru_cache_options_set_no_dump_allocator(opt: *mut DBLRUCacheOptions);
     pub fn crocksdb_cache_create_lru(opt: *mut DBLRUCacheOptions) -> *mut DBCache;
     pub fn crocksdb_cache_destroy(cache: *mut DBCache);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,8 @@ pub use metadata::{ColumnFamilyMetaData, LevelMetaData, SstFileMetaData};
 pub use perf_context::{get_perf_level, set_perf_level, IOStatsContext, PerfContext, PerfLevel};
 pub use rocksdb::{
     load_latest_options, run_ldb_tool, set_external_sst_file_global_seq_no, BackupEngine, CFHandle,
-    Cache, DBIterator, DBVector, Env, ExternalSstFileInfo, Kv, Range, SeekKey, SequentialFile,
-    SstFileWriter, Writable, WriteBatch, DB,
+    Cache, DBIterator, DBVector, Env, ExternalSstFileInfo, Kv, MemoryAllocator, Range, SeekKey,
+    SequentialFile, SstFileWriter, Writable, WriteBatch, DB,
 };
 pub use rocksdb_options::{
     BlockBasedOptions, CColumnFamilyDescriptor, ColumnFamilyOptions, CompactOptions,

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -2346,11 +2346,13 @@ pub struct MemoryAllocator {
 }
 
 impl MemoryAllocator {
-    pub fn new_jemalloc_memory_allocator() -> MemoryAllocator {
+    #[cfg(feature = "jemalloc")]
+    pub fn new_jemalloc_memory_allocator() -> Result<MemoryAllocator, String> {
         unsafe {
-            MemoryAllocator {
-                inner: crocksdb_ffi::crocksdb_jemalloc_nodump_allocator_create(),
-            }
+            let allocator = MemoryAllocator {
+                inner: ffi_try!(crocksdb_ffi::crocksdb_jemalloc_nodump_allocator_create()),
+            };
+            Ok(allocator)
         }
     }
 }

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -18,6 +18,7 @@ use crocksdb_ffi::{
     DBWriteBatch,
 };
 use libc::{self, c_char, c_int, c_void, size_t};
+use librocksdb_sys::DBMemoryAllocator;
 use metadata::ColumnFamilyMetaData;
 use rocksdb_options::{
     CColumnFamilyDescriptor, ColumnFamilyDescriptor, ColumnFamilyOptions, CompactOptions,
@@ -2336,6 +2337,28 @@ impl Drop for Cache {
     fn drop(&mut self) {
         unsafe {
             crocksdb_ffi::crocksdb_cache_destroy(self.inner);
+        }
+    }
+}
+
+pub struct MemoryAllocator {
+    pub inner: *mut DBMemoryAllocator,
+}
+
+impl MemoryAllocator {
+    pub fn new_jemalloc_memory_allocator() -> MemoryAllocator {
+        unsafe {
+            MemoryAllocator {
+                inner: crocksdb_ffi::crocksdb_jemalloc_nodump_allocator_create(),
+            }
+        }
+    }
+}
+
+impl Drop for MemoryAllocator {
+    fn drop(&mut self) {
+        unsafe {
+            crocksdb_ffi::crocksdb_memory_allocator_destroy(self.inner);
         }
     }
 }

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -1877,6 +1877,12 @@ impl LRUCacheOptions {
             );
         }
     }
+
+    pub fn set_no_dump_allocator(&mut self) {
+        unsafe {
+            crocksdb_ffi::crocksdb_lru_cache_options_set_no_dump_allocator(self.inner);
+        }
+    }
 }
 
 impl Drop for LRUCacheOptions {

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -1878,7 +1878,7 @@ impl LRUCacheOptions {
         }
     }
 
-    pub fn set_memory_allocator(&mut self, allocator: MemoryAllocator) {
+    pub fn set_memory_allocator(&mut self, allocator: &MemoryAllocator) {
         unsafe {
             crocksdb_ffi::crocksdb_lru_cache_options_set_memory_allocator(
                 self.inner,

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -27,8 +27,8 @@ use event_listener::{new_event_listener, EventListener};
 use libc::{self, c_double, c_int, c_uchar, c_void, size_t};
 use merge_operator::MergeFn;
 use merge_operator::{self, full_merge_callback, partial_merge_callback, MergeOperatorCallback};
-use rocksdb::Cache;
 use rocksdb::Env;
+use rocksdb::{Cache, MemoryAllocator};
 use slice_transform::{new_slice_transform, SliceTransform};
 use std::ffi::{CStr, CString};
 use std::mem;
@@ -1878,9 +1878,12 @@ impl LRUCacheOptions {
         }
     }
 
-    pub fn set_no_dump_allocator(&mut self) {
+    pub fn set_memory_allocator(&mut self, allocator: MemoryAllocator) {
         unsafe {
-            crocksdb_ffi::crocksdb_lru_cache_options_set_no_dump_allocator(self.inner);
+            crocksdb_ffi::crocksdb_lru_cache_options_set_memory_allocator(
+                self.inner,
+                allocator.inner,
+            );
         }
     }
 }

--- a/tests/cases/test_rocksdb_options.rs
+++ b/tests/cases/test_rocksdb_options.rs
@@ -319,6 +319,7 @@ fn test_set_lru_cache() {
     DB::open_cf(opts, path.path().to_str().unwrap(), vec!["default"]).unwrap();
 }
 
+#[cfg(feature = "jemalloc")]
 #[test]
 fn test_set_jemalloc_nodump_allocator_for_lru_cache() {
     let path = TempDir::new("_rust_rocksdb_set_jemalloc_nodump_allocator").expect("");
@@ -327,7 +328,7 @@ fn test_set_jemalloc_nodump_allocator_for_lru_cache() {
     opts.create_if_missing(true);
     let mut block_opts = BlockBasedOptions::new();
     let mut cache_opts = LRUCacheOptions::new();
-    cache_opts.set_memory_allocator(MemoryAllocator::new_jemalloc_memory_allocator());
+    cache_opts.set_memory_allocator(MemoryAllocator::new_jemalloc_memory_allocator().unwrap());
     cache_opts.set_capacity(8388608);
     block_opts.set_block_cache(&Cache::new_lru_cache(cache_opts));
     cf_opts.set_block_based_table_factory(&block_opts);

--- a/tests/cases/test_rocksdb_options.rs
+++ b/tests/cases/test_rocksdb_options.rs
@@ -15,6 +15,7 @@ use rocksdb::crocksdb_ffi::{
     CompactionPriority, DBCompressionType, DBInfoLogLevel as InfoLogLevel, DBRateLimiterMode,
     DBStatisticsHistogramType as HistogramType, DBStatisticsTickerType as TickerType,
 };
+use rocksdb::rocksdb::MemoryAllocator;
 use rocksdb::{
     BlockBasedOptions, Cache, ColumnFamilyOptions, CompactOptions, DBOptions, Env,
     FifoCompactionOptions, IndexType, LRUCacheOptions, ReadOptions, SeekKey, SliceTransform,
@@ -319,14 +320,14 @@ fn test_set_lru_cache() {
 }
 
 #[test]
-fn test_set_no_dump_lru_cache() {
-    let path = TempDir::new("_rust_rocksdb_set_set_no_dump_lru_cache").expect("");
+fn test_set_jemalloc_nodump_allocator_for_lru_cache() {
+    let path = TempDir::new("_rust_rocksdb_set_jemalloc_nodump_allocator").expect("");
     let mut opts = DBOptions::new();
     let mut cf_opts = ColumnFamilyOptions::new();
     opts.create_if_missing(true);
     let mut block_opts = BlockBasedOptions::new();
     let mut cache_opts = LRUCacheOptions::new();
-    cache_opts.set_no_dump_allocator();
+    cache_opts.set_memory_allocator(MemoryAllocator::new_jemalloc_memory_allocator());
     cache_opts.set_capacity(8388608);
     block_opts.set_block_cache(&Cache::new_lru_cache(cache_opts));
     cf_opts.set_block_based_table_factory(&block_opts);

--- a/tests/cases/test_rocksdb_options.rs
+++ b/tests/cases/test_rocksdb_options.rs
@@ -319,6 +319,21 @@ fn test_set_lru_cache() {
 }
 
 #[test]
+fn test_set_no_dump_lru_cache() {
+    let path = TempDir::new("_rust_rocksdb_set_set_no_dump_lru_cache").expect("");
+    let mut opts = DBOptions::new();
+    let mut cf_opts = ColumnFamilyOptions::new();
+    opts.create_if_missing(true);
+    let mut block_opts = BlockBasedOptions::new();
+    let mut cache_opts = LRUCacheOptions::new();
+    cache_opts.set_no_dump_allocator();
+    cache_opts.set_capacity(8388608);
+    block_opts.set_block_cache(&Cache::new_lru_cache(cache_opts));
+    cf_opts.set_block_based_table_factory(&block_opts);
+    DB::open_cf(opts, path.path().to_str().unwrap(), vec!["default"]).unwrap();
+}
+
+#[test]
 fn test_set_cache_index_and_filter_blocks_with_high_priority() {
     let path = TempDir::new("_rust_rocksdb_set_cache_and_index_with_high_priority").expect("");
     let mut opts = DBOptions::new();


### PR DESCRIPTION
Adding LRUCacheOptions::set_no_dump_allocator, so we can use JemallocNoDumpAllocator of rocksdb to exclude some LRU Cache, like block cache, from core dump.