### PR TITLE
Update titan branch to tikv-3.0 specific branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	branch = tikv-3.0
 [submodule "titan"]
 	path = librocksdb_sys/libtitan_sys/titan
-  url = https://github.com/pingcap/titan.git
-  branch = tikv-3.0
+	url = https://github.com/pingcap/titan.git
+	branch = tikv-3.0

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,5 @@
 	branch = tikv-3.0
 [submodule "titan"]
 	path = librocksdb_sys/libtitan_sys/titan
-	url = https://github.com/pingcap/titan.git
+  url = https://github.com/pingcap/titan.git
+  branch = tikv-3.0


### PR DESCRIPTION
Created a tikv-3.0 branch for Titan and update rust-rocksdb tikv-3.0 branch to point to it. Also cherry-picking the following Titan changes:
```
19ea115 2019-08-19 yiwu@pingcap.com     cmake auto clone rocksdb (#60)
f0964aa 2019-08-20 keao.yang@yahoo.com  Add benchmark script (#57)
d7b4091 2019-08-04 wujy.cs@gmail.com    Limit blob file read IO with rate_limiter (#54)
```

Signed-off-by: Yi Wu <yiwu@pingcap.com>