### PR TITLE
support doubly skiplist

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -2631,6 +2631,13 @@ void crocksdb_options_set_memtable_huge_page_size(crocksdb_options_t* opt,
                                                  size_t v) {
   opt->rep.memtable_huge_page_size = v;
 }
+const char* crocksdb_options_get_memtable_factory_name(
+    crocksdb_options_t *opt) {
+  if (!opt->rep.memtable_factory) {
+     return nullptr;
+  }
+  return opt->rep.memtable_factory->Name();
+}
 
 void crocksdb_options_set_hash_skip_list_rep(
     crocksdb_options_t *opt, size_t bucket_count,
@@ -2643,6 +2650,11 @@ void crocksdb_options_set_hash_skip_list_rep(
 void crocksdb_options_set_hash_link_list_rep(
     crocksdb_options_t *opt, size_t bucket_count) {
   opt->rep.memtable_factory.reset(rocksdb::NewHashLinkListRepFactory(bucket_count));
+}
+
+void crocksdb_options_set_doubly_skip_list_rep(crocksdb_options_t *opt) {
+  rocksdb::MemTableRepFactory* factory = new rocksdb::DoublySkipListFactory();
+  opt->rep.memtable_factory.reset(factory);
 }
 
 void crocksdb_options_set_plain_table_factory(

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1024,6 +1024,7 @@ crocksdb_options_set_delete_obsolete_files_period_micros(crocksdb_options_t*,
                                                         uint64_t);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_prepare_for_bulk_load(
     crocksdb_options_t*);
+extern C_ROCKSDB_LIBRARY_API const char* crocksdb_options_get_memtable_factory_name(crocksdb_options_t *opt);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_memtable_vector_rep(
     crocksdb_options_t*);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_memtable_prefix_bloom_size_ratio(
@@ -1034,6 +1035,7 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_hash_skip_list_rep(
     crocksdb_options_t*, size_t, int32_t, int32_t);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_hash_link_list_rep(
     crocksdb_options_t*, size_t);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_doubly_skip_list_rep(crocksdb_options_t *opt);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_plain_table_factory(
     crocksdb_options_t*, uint32_t, int, double, size_t);
 

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -479,12 +479,14 @@ extern "C" {
     pub fn crocksdb_options_set_keep_log_file_num(options: *mut Options, num: size_t);
     pub fn crocksdb_options_set_recycle_log_file_num(options: *mut Options, num: size_t);
     pub fn crocksdb_options_set_max_manifest_file_size(options: *mut Options, bytes: u64);
+    pub fn crocksdb_options_get_memtable_factory_name(options: *mut Options) -> *const c_char;
     pub fn crocksdb_options_set_hash_skip_list_rep(
         options: *mut Options,
         bytes: u64,
         a1: i32,
         a2: i32,
     );
+    pub fn crocksdb_options_set_doubly_skip_list_rep(options: *mut Options);
     pub fn crocksdb_options_set_compaction_style(options: *mut Options, cs: DBCompactionStyle);
     pub fn crocksdb_options_set_fifo_compaction_options(
         options: *mut Options,

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -33,13 +33,13 @@ use std::ffi::{CStr, CString};
 use std::mem;
 use std::path::Path;
 use std::ptr;
+use std::ptr::null;
 use std::sync::Arc;
 use table_filter::{destroy_table_filter, table_filter, TableFilter};
 use table_properties_collector_factory::{
     new_table_properties_collector_factory, TablePropertiesCollectorFactory,
 };
 use titan::TitanDBOptions;
-use std::ptr::null;
 
 #[derive(Default, Debug)]
 pub struct HistogramData {
@@ -1040,7 +1040,8 @@ impl DBOptions {
 
     pub fn get_memtable_name(&self) -> Option<&str> {
         unsafe {
-            let memtable_name = crocksdb_ffi::crocksdb_options_get_memtable_factory_name(self.inner);
+            let memtable_name =
+                crocksdb_ffi::crocksdb_options_get_memtable_factory_name(self.inner);
             if memtable_name.is_null() {
                 return None;
             }
@@ -1541,7 +1542,8 @@ impl ColumnFamilyOptions {
 
     pub fn get_memtable_factory_name(&self) -> Option<&str> {
         unsafe {
-            let memtable_name = crocksdb_ffi::crocksdb_options_get_memtable_factory_name(self.inner);
+            let memtable_name =
+                crocksdb_ffi::crocksdb_options_get_memtable_factory_name(self.inner);
             if memtable_name.is_null() {
                 return None;
             }

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -39,6 +39,7 @@ use table_properties_collector_factory::{
     new_table_properties_collector_factory, TablePropertiesCollectorFactory,
 };
 use titan::TitanDBOptions;
+use std::ptr::null;
 
 #[derive(Default, Debug)]
 pub struct HistogramData {
@@ -1030,6 +1031,22 @@ impl DBOptions {
             crocksdb_ffi::crocksdb_options_set_paranoid_checks(self.inner, enable as u8);
         }
     }
+
+    pub fn set_doubly_skiplist(&self) {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_doubly_skip_list_rep(self.inner);
+        }
+    }
+
+    pub fn get_memtable_name(&self) -> Option<&str> {
+        unsafe {
+            let memtable_name = crocksdb_ffi::crocksdb_options_get_memtable_factory_name(self.inner);
+            if memtable_name.is_null() {
+                return None;
+            }
+            Some(CStr::from_ptr(memtable_name).to_str().unwrap())
+        }
+    }
 }
 
 pub struct ColumnFamilyOptions {
@@ -1513,6 +1530,22 @@ impl ColumnFamilyOptions {
     pub fn set_vector_memtable_factory(&mut self, reserved_bytes: u64) {
         unsafe {
             crocksdb_ffi::crocksdb_options_set_vector_memtable_factory(self.inner, reserved_bytes);
+        }
+    }
+
+    pub fn set_doubly_skiplist(&self) {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_doubly_skip_list_rep(self.inner);
+        }
+    }
+
+    pub fn get_memtable_factory_name(&self) -> Option<&str> {
+        unsafe {
+            let memtable_name = crocksdb_ffi::crocksdb_options_get_memtable_factory_name(self.inner);
+            if memtable_name.is_null() {
+                return None;
+            }
+            Some(CStr::from_ptr(memtable_name).to_str().unwrap())
         }
     }
 }

--- a/tests/cases/test_column_family.rs
+++ b/tests/cases/test_column_family.rs
@@ -147,3 +147,14 @@ fn test_provided_merge(
     }
     result
 }
+
+#[test]
+pub fn test_column_family_option_use_doubly_skiplist() {
+    let mut cf_opts = ColumnFamilyOptions::new();
+    let memtable_name = cf_opts.get_memtable_factory_name();
+    assert!(memtable_name.is_some());
+    assert_eq!("SkipListFactory", memtable_name.unwrap());
+    cf_opts.set_doubly_skiplist();
+    let memtable_name = cf_opts.get_memtable_factory_name();
+    assert_eq!("DoublySkipListFactory", memtable_name.unwrap());
+}


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

Update `ColumnFamilyOptions` to support `DoublySkipList` in memtable.