### PR TITLE
Add force_consistency_checks option

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -2738,6 +2738,11 @@ void crocksdb_options_set_delayed_write_rate(crocksdb_options_t *opt, uint64_t d
   opt->rep.delayed_write_rate = delayed_write_rate;
 }
 
+void crocksdb_options_set_force_consistency_checks(crocksdb_options_t *opt,
+                                                   unsigned char v) {
+  opt->rep.force_consistency_checks = v;
+}
+
 char *crocksdb_options_statistics_get_string(crocksdb_options_t *opt) {
   if (opt->rep.statistics) {
     rocksdb::Statistics* statistics = opt->rep.statistics.get();

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1121,6 +1121,8 @@ crocksdb_options_set_compaction_priority(crocksdb_options_t *, unsigned char);
 
 extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_delayed_write_rate(
     crocksdb_options_t*, uint64_t);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_options_set_force_consistency_checks(
+    crocksdb_options_t*, unsigned char);
 
 /* RateLimiter */
 extern C_ROCKSDB_LIBRARY_API crocksdb_ratelimiter_t* crocksdb_ratelimiter_create(

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -603,6 +603,7 @@ extern "C" {
         ratio: c_double,
     );
     pub fn crocksdb_options_set_delayed_write_rate(options: *mut Options, rate: u64);
+    pub fn crocksdb_options_set_force_consistency_checks(options: *mut Options, v: bool);
     pub fn crocksdb_options_set_ratelimiter(options: *mut Options, limiter: *mut DBRateLimiter);
     pub fn crocksdb_options_set_info_log(options: *mut Options, logger: *mut DBLogger);
     pub fn crocksdb_options_get_block_cache_usage(options: *const Options) -> usize;

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -1541,6 +1541,12 @@ impl ColumnFamilyOptions {
         }
     }
 
+    pub fn set_force_consistency_checks(&mut self, v: bool) {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_force_consistency_checks(self.inner, v);
+        }
+    }
+
     pub fn get_block_cache_usage(&self) -> u64 {
         unsafe { crocksdb_ffi::crocksdb_options_get_block_cache_usage(self.inner) as u64 }
     }

--- a/tests/cases/test_rocksdb_options.rs
+++ b/tests/cases/test_rocksdb_options.rs
@@ -402,7 +402,7 @@ fn test_set_optimize_filters_for_hits() {
 }
 
 #[test]
-fn test_set_optimize_filters_for_hits() {
+fn test_set_force_consistency_checks() {
     let path = TempDir::new("_rust_rocksdb_force_consistency_checks").expect("");
     let mut opts = DBOptions::new();
     let mut cf_opts = ColumnFamilyOptions::new();

--- a/tests/cases/test_rocksdb_options.rs
+++ b/tests/cases/test_rocksdb_options.rs
@@ -402,6 +402,21 @@ fn test_set_optimize_filters_for_hits() {
 }
 
 #[test]
+fn test_set_optimize_filters_for_hits() {
+    let path = TempDir::new("_rust_rocksdb_force_consistency_checks").expect("");
+    let mut opts = DBOptions::new();
+    let mut cf_opts = ColumnFamilyOptions::new();
+    opts.create_if_missing(true);
+    cf_opts.set_force_consistency_checks(true);
+    DB::open_cf(
+        opts,
+        path.path().to_str().unwrap(),
+        vec![("default", cf_opts)],
+    )
+    .unwrap();
+}
+
+#[test]
 fn test_get_block_cache_usage() {
     let path = TempDir::new("_rust_rocksdb_set_cache_and_index").expect("");
 


### PR DESCRIPTION
The option is useful for catching LSM tree corruption. Adding it.

Signed-off-by: Yi Wu <yiwu@pingcap.com>