### PR TITLE
add support to set compression options

### DIFF
--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -654,6 +654,13 @@ extern "C" {
         compression_style_no: DBCompressionType,
     );
     pub fn crocksdb_options_get_compression(options: *mut Options) -> DBCompressionType;
+    pub fn crocksdb_options_set_compression_options(
+        options: *mut Options,
+        window_bits: c_int,
+        level: c_int,
+        strategy: c_int,
+        max_dict_bytes: c_int,
+    );
     pub fn crocksdb_options_set_compression_per_level(
         options: *mut Options,
         level_values: *const DBCompressionType,

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -1346,6 +1346,24 @@ impl ColumnFamilyOptions {
         unsafe { crocksdb_ffi::crocksdb_options_get_compression(self.inner) }
     }
 
+    pub fn set_compression_options(
+        &mut self,
+        window_bits: i32,
+        level: i32,
+        strategy: i32,
+        max_dict_bytes: i32,
+    ) {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_compression_options(
+                self.inner,
+                window_bits,
+                level,
+                strategy,
+                max_dict_bytes,
+            )
+        }
+    }
+
     pub fn compression_per_level(&mut self, level_types: &[DBCompressionType]) {
         unsafe {
             crocksdb_ffi::crocksdb_options_set_compression_per_level(


### PR DESCRIPTION
add `set_compression_options` for `ColumnFamilyOptions` so that we can set the `compression level` when generate sst files