### PR TITLE
librocksdb_sys: bump tikv-jemalloc-sys to 0.6.0

### DIFF
--- a/librocksdb_sys/Cargo.toml
+++ b/librocksdb_sys/Cargo.toml
@@ -34,7 +34,7 @@ cmake = "0.1"
 bindgen = { version = "0.65", default-features = false, features = ["runtime"] }
 
 [dependencies.tikv-jemalloc-sys]
-version = "0.5.0"
+version = "0.6.0"
 optional = true
 features = ["unprefixed_malloc_on_supported_platforms"]
 


### PR DESCRIPTION
## Summary
bump `librocksdb_sys` dependency `tikv-jemalloc-sys` from `0.5.0` to `0.6.0` to align jemalloc dependency version with newer consumers (for example `jemalloc_pprof 0.8.x` dependency chain)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the underlying memory allocator dependency to a newer release to enhance stability, performance, and compatibility across platforms.
  * No user-facing API or behavior changes are expected; this is an internal dependency update to improve reliability and resource management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->