### PR TITLE
librocksdb_sys: link liburing when RocksDB enables io_uring

### DIFF
--- a/librocksdb_sys/build.rs
+++ b/librocksdb_sys/build.rs
@@ -17,6 +17,7 @@ extern crate cmake;
 
 use cc::Build;
 use cmake::Config;
+use std::fs;
 use std::path::{Path, PathBuf};
 use std::{env, str};
 
@@ -170,6 +171,7 @@ fn build_rocksdb() -> Build {
         .very_verbose(true)
         .build();
     let build_dir = format!("{}/build", dst.display());
+    link_optional_uring(&build_dir);
     let mut build = Build::new();
     if target_os == "windows" {
         let profile = match &*env::var("PROFILE").unwrap_or_else(|_| "debug".to_owned()) {
@@ -220,4 +222,43 @@ fn build_rocksdb() -> Build {
         cur_dir.join("rocksdb").display()
     );
     build
+}
+
+fn link_optional_uring(build_dir: &str) {
+    let cache_path = Path::new(build_dir).join("CMakeCache.txt");
+    let cache = match fs::read_to_string(&cache_path) {
+        Ok(cache) => cache,
+        Err(_) => return,
+    };
+
+    let uring_path = cache
+        .lines()
+        .find_map(|line| line.strip_prefix("uring_LIBRARIES:FILEPATH="))
+        .map(str::trim)
+        .filter(|path| !path.is_empty());
+
+    let Some(uring_path) = uring_path else {
+        return;
+    };
+
+    let path = Path::new(uring_path);
+    let Some(parent) = path.parent() else {
+        return;
+    };
+    let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
+        return;
+    };
+    let Some(libname) = file_name
+        .strip_prefix("lib")
+        .and_then(|name| name.split('.').next())
+    else {
+        return;
+    };
+
+    println!("cargo:rustc-link-search=native={}", parent.display());
+    if file_name.ends_with(".a") {
+        println!("cargo:rustc-link-lib=static={}", libname);
+    } else {
+        println!("cargo:rustc-link-lib=dylib={}", libname);
+    }
 }

--- a/librocksdb_sys/build.rs
+++ b/librocksdb_sys/build.rs
@@ -171,7 +171,6 @@ fn build_rocksdb() -> Build {
         .very_verbose(true)
         .build();
     let build_dir = format!("{}/build", dst.display());
-    link_optional_uring(&build_dir);
     let mut build = Build::new();
     if target_os == "windows" {
         let profile = match &*env::var("PROFILE").unwrap_or_else(|_| "debug".to_owned()) {
@@ -212,6 +211,7 @@ fn build_rocksdb() -> Build {
     println!("cargo:rustc-link-lib=static=lz4");
     println!("cargo:rustc-link-lib=static=zstd");
     println!("cargo:rustc-link-lib=static=snappy");
+    link_optional_uring(&build_dir);
 
     println!(
         "cargo:rerun-if-changed={}",


### PR DESCRIPTION
Fix missing `liburing` linkage in `librocksdb_sys`.

When RocksDB is built with `WITH_LIBURING=ON`, CMake enables `io_uring` support, but `build.rs` does not forward `liburing` to Cargo's final link step. This causes Linux builds to fail with undefined `io_uring_*` symbols.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build now optionally detects and links liburing if present on the system, automatically choosing static or dynamic linking as appropriate.
  * If liburing is not detected or parsing fails, the build proceeds without emitting any liburing link settings (graceful fallback).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->