### PR TITLE
librocksdb_sys: Implement a writable file interface

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -4378,6 +4378,39 @@ void crocksdb_sequential_file_destroy(crocksdb_sequential_file_t* file) {
   delete file;
 }
 
+crocksdb_writablefile_t* crocksdb_writable_file_create(
+    crocksdb_env_t* env, const char* path, const crocksdb_envoptions_t* opts,
+    char** errptr) {
+  std::unique_ptr<WritableFile> result;
+  if (SaveError(errptr, env->rep->NewWritableFile(path, &result, opts->rep))) {
+    return nullptr;
+  }
+  auto file = new crocksdb_writablefile_t;
+  file->rep = result.release();
+  return file;
+}
+
+void crocksdb_writable_file_append(crocksdb_writablefile_t* file,
+                                   const char* data, size_t len,
+                                   char** errptr) {
+  SaveError(errptr, file->rep->Append(Slice(data, len)));
+}
+
+void crocksdb_writable_file_flush(crocksdb_writablefile_t* file,
+                                  char** errptr) {
+  SaveError(errptr, file->rep->Flush());
+}
+
+void crocksdb_writable_file_close(crocksdb_writablefile_t* file,
+                                  char** errptr) {
+  SaveError(errptr, file->rep->Close());
+}
+
+void crocksdb_writable_file_destroy(crocksdb_writablefile_t* file) {
+  delete file->rep;
+  delete file;
+}
+
 #ifdef OPENSSL
 crocksdb_file_encryption_info_t* crocksdb_file_encryption_info_create() {
   crocksdb_file_encryption_info_t* file_info =

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1796,8 +1796,7 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_sequential_file_destroy(
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_writablefile_t*
 crocksdb_writable_file_create(crocksdb_env_t* env, const char* path,
-                              const crocksdb_envoptions_t* opts,
-                              char** errptr);
+                              const crocksdb_envoptions_t* opts, char** errptr);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_writable_file_append(
     crocksdb_writablefile_t*, const char* data, size_t len, char** errptr);
 extern C_ROCKSDB_LIBRARY_API void crocksdb_writable_file_flush(

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -2023,7 +2023,7 @@ crocksdb_slicetransform_create(
     unsigned char (*in_range)(void*, const char* key, size_t length),
     const char* (*name)(void*));
 extern C_ROCKSDB_LIBRARY_API crocksdb_slicetransform_t*
-    crocksdb_slicetransform_create_fixed_prefix(size_t);
+crocksdb_slicetransform_create_fixed_prefix(size_t);
 extern C_ROCKSDB_LIBRARY_API crocksdb_slicetransform_t*
 crocksdb_slicetransform_create_noop();
 extern C_ROCKSDB_LIBRARY_API void crocksdb_slicetransform_destroy(

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1794,6 +1794,19 @@ extern C_ROCKSDB_LIBRARY_API void crocksdb_sequential_file_skip(
 extern C_ROCKSDB_LIBRARY_API void crocksdb_sequential_file_destroy(
     crocksdb_sequential_file_t*);
 
+extern C_ROCKSDB_LIBRARY_API crocksdb_writablefile_t*
+crocksdb_writable_file_create(crocksdb_env_t* env, const char* path,
+                              const crocksdb_envoptions_t* opts,
+                              char** errptr);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_writable_file_append(
+    crocksdb_writablefile_t*, const char* data, size_t len, char** errptr);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_writable_file_flush(
+    crocksdb_writablefile_t*, char** errptr);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_writable_file_close(
+    crocksdb_writablefile_t*, char** errptr);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_writable_file_destroy(
+    crocksdb_writablefile_t*);
+
 /* KeyManagedEncryptedEnv */
 
 #ifdef OPENSSL

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -154,6 +154,8 @@ pub struct DBEnv(c_void);
 #[repr(C)]
 pub struct DBSequentialFile(c_void);
 #[repr(C)]
+pub struct DBWritableFile(c_void);
+#[repr(C)]
 pub struct DBColumnFamilyMetaData(c_void);
 #[repr(C)]
 pub struct DBLevelMetaData(c_void);
@@ -1882,6 +1884,23 @@ extern "C" {
         err: *mut *mut c_char,
     );
     pub fn crocksdb_sequential_file_destroy(file: *mut DBSequentialFile);
+
+    // WritableFile
+    pub fn crocksdb_writable_file_create(
+        env: *mut DBEnv,
+        path: *const c_char,
+        opts: *mut EnvOptions,
+        err: *mut *mut c_char,
+    ) -> *mut DBWritableFile;
+    pub fn crocksdb_writable_file_append(
+        file: *mut DBWritableFile,
+        data: *const u8,
+        len: size_t,
+        err: *mut *mut c_char,
+    );
+    pub fn crocksdb_writable_file_flush(file: *mut DBWritableFile, err: *mut *mut c_char);
+    pub fn crocksdb_writable_file_close(file: *mut DBWritableFile, err: *mut *mut c_char);
+    pub fn crocksdb_writable_file_destroy(file: *mut DBWritableFile);
 
     // IngestExternalFileOptions
     pub fn crocksdb_ingestexternalfileoptions_create() -> *mut IngestExternalFileOptions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,8 @@ pub use perf_context::{
 pub use rocksdb::{
     load_latest_options, run_ldb_tool, run_sst_dump_tool, set_external_sst_file_global_seq_no,
     BackupEngine, CFHandle, Cache, DBIterator, DBVector, Env, ExternalSstFileInfo, MapProperty,
-    MemoryAllocator, Range, SeekKey, SequentialFile, SstFileReader, SstFileWriter, Writable, DB,
+    MemoryAllocator, Range, SeekKey, SequentialFile, SstFileReader, SstFileWriter, Writable,
+    WritableFile, DB,
 };
 pub use rocksdb_options::{
     BlockBasedOptions, CColumnFamilyDescriptor, ColumnFamilyOptions, CompactOptions,

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -15,7 +15,7 @@
 use crocksdb_ffi::{
     self, DBBackupEngine, DBCFHandle, DBCache, DBCompressionType, DBEnv, DBInstance, DBMapProperty,
     DBPinnableSlice, DBPostWriteCallback, DBSequentialFile, DBTablePropertiesCollection,
-    DBTitanDBOptions, DBWriteBatch,
+    DBTitanDBOptions, DBWritableFile, DBWriteBatch,
 };
 use libc::{self, c_char, c_int, c_void, size_t};
 use librocksdb_sys::DBMemoryAllocator;
@@ -2819,6 +2819,18 @@ impl Env {
         }
     }
 
+    pub fn new_writable_file(&self, path: &str, opts: EnvOptions) -> Result<WritableFile, String> {
+        unsafe {
+            let file_path = CString::new(path).unwrap();
+            let file = ffi_try!(crocksdb_writable_file_create(
+                self.inner,
+                file_path.as_ptr(),
+                opts.inner
+            ));
+            Ok(WritableFile::new(file))
+        }
+    }
+
     pub fn file_exists(&self, path: &str) -> Result<(), String> {
         unsafe {
             let file_path = CString::new(path).unwrap();
@@ -2904,6 +2916,68 @@ impl io::Read for SequentialFile {
                 ));
             }
             Ok(size)
+        }
+    }
+}
+
+pub struct WritableFile {
+    inner: *mut DBWritableFile,
+}
+
+impl WritableFile {
+    fn new(inner: *mut DBWritableFile) -> WritableFile {
+        WritableFile { inner }
+    }
+
+    pub fn close(&mut self) -> Result<(), String> {
+        unsafe {
+            ffi_try!(crocksdb_writable_file_close(self.inner));
+            Ok(())
+        }
+    }
+}
+
+unsafe impl Send for WritableFile {}
+
+impl io::Write for WritableFile {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        unsafe {
+            let mut err = ptr::null_mut();
+            crocksdb_ffi::crocksdb_writable_file_append(
+                self.inner,
+                buf.as_ptr(),
+                buf.len() as size_t,
+                &mut err,
+            );
+            if !err.is_null() {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    crocksdb_ffi::error_message(err),
+                ));
+            }
+            Ok(buf.len())
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        unsafe {
+            let mut err = ptr::null_mut();
+            crocksdb_ffi::crocksdb_writable_file_flush(self.inner, &mut err);
+            if !err.is_null() {
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    crocksdb_ffi::error_message(err),
+                ));
+            }
+            Ok(())
+        }
+    }
+}
+
+impl Drop for WritableFile {
+    fn drop(&mut self) {
+        unsafe {
+            crocksdb_ffi::crocksdb_writable_file_destroy(self.inner);
         }
     }
 }
@@ -3058,6 +3132,7 @@ pub fn run_sst_dump_tool(sst_dump_args: &[String], opts: &DBOptions) {
 mod test {
     use librocksdb_sys::DBValueType;
     use std::fs;
+    use std::io::{Read, Write};
     use std::path::Path;
     use std::str;
     use std::string::String;
@@ -3918,6 +3993,17 @@ mod test {
     #[test]
     fn test_env_operations() {
         let env = Env::new_mem();
+        assert!(env.file_exists("a").unwrap_err().contains("NotFound"));
+        let mut writable = env.new_writable_file("a", EnvOptions::new()).unwrap();
+        writable.write_all(b"hello").unwrap();
+        writable.flush().unwrap();
+        writable.close().unwrap();
+        env.file_exists("a").unwrap();
+        let mut sequential = env.new_sequential_file("a", EnvOptions::new()).unwrap();
+        let mut buf = Vec::new();
+        sequential.read_to_end(&mut buf).unwrap();
+        assert_eq!(&buf, b"hello");
+        env.delete_file("a").unwrap();
         assert!(env.file_exists("a").unwrap_err().contains("NotFound"));
         env.set_background_threads(4);
         env.set_background_threads(0);

--- a/src/rocksdb.rs
+++ b/src/rocksdb.rs
@@ -2922,18 +2922,27 @@ impl io::Read for SequentialFile {
 
 pub struct WritableFile {
     inner: *mut DBWritableFile,
+    closed: bool,
 }
 
 impl WritableFile {
     fn new(inner: *mut DBWritableFile) -> WritableFile {
-        WritableFile { inner }
+        WritableFile {
+            inner,
+            closed: false,
+        }
     }
 
     pub fn close(&mut self) -> Result<(), String> {
+        if self.closed {
+            return Ok(());
+        }
+
         unsafe {
             ffi_try!(crocksdb_writable_file_close(self.inner));
-            Ok(())
         }
+        self.closed = true;
+        Ok(())
     }
 }
 
@@ -2977,7 +2986,10 @@ impl io::Write for WritableFile {
 impl Drop for WritableFile {
     fn drop(&mut self) {
         unsafe {
-            crocksdb_ffi::crocksdb_writable_file_destroy(self.inner);
+            if !self.inner.is_null() {
+                let _ = self.close();
+                crocksdb_ffi::crocksdb_writable_file_destroy(self.inner);
+            }
         }
     }
 }
@@ -3998,12 +4010,24 @@ mod test {
         writable.write_all(b"hello").unwrap();
         writable.flush().unwrap();
         writable.close().unwrap();
+        writable.close().unwrap();
         env.file_exists("a").unwrap();
         let mut sequential = env.new_sequential_file("a", EnvOptions::new()).unwrap();
         let mut buf = Vec::new();
         sequential.read_to_end(&mut buf).unwrap();
         assert_eq!(&buf, b"hello");
+
+        {
+            let mut writable = env.new_writable_file("b", EnvOptions::new()).unwrap();
+            writable.write_all(b"bye").unwrap();
+        }
+        let mut sequential = env.new_sequential_file("b", EnvOptions::new()).unwrap();
+        let mut buf = Vec::new();
+        sequential.read_to_end(&mut buf).unwrap();
+        assert_eq!(&buf, b"bye");
+
         env.delete_file("a").unwrap();
+        env.delete_file("b").unwrap();
         assert!(env.file_exists("a").unwrap_err().contains("NotFound"));
         env.set_background_threads(4);
         env.set_background_threads(0);


### PR DESCRIPTION
Implement a writable file interface to enable SST data streaming via memory-copy level writes instead of KV-level writes.

```Rust
let env = Arc::new(Env::new_mem());
let file = env
    .new_writable_file(path, EnvOptions::new())
    .unwrap();
let sst_file_content_stream = self.download_file_from_external_storage(path);
io::copy(&mut sst_file_content_stream, &mut file).unwrap();
```

The implementation is modeled after `sequential_file`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added writable-file support to the RocksDB environment: create, write/append, flush, close, and safe cleanup; integrates with Rust's standard I/O (Write/flush) and re-exports the writable-file type.

* **Tests**
  * Added tests exercising writable-file lifecycle: create, write, flush, idempotent close, read-back verification, and deletion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->