### PR TITLE
options: expose direct-IO setters for the SST writer and reader

### DIFF
--- a/librocksdb_sys/crocksdb/c.cc
+++ b/librocksdb_sys/crocksdb/c.cc
@@ -4346,6 +4346,11 @@ crocksdb_envoptions_t* crocksdb_envoptions_create() {
 
 void crocksdb_envoptions_destroy(crocksdb_envoptions_t* opt) { delete opt; }
 
+void crocksdb_envoptions_set_use_direct_writes(crocksdb_envoptions_t* opt,
+                                               unsigned char v) {
+  opt->rep.use_direct_writes = v;
+}
+
 crocksdb_sequential_file_t* crocksdb_sequential_file_create(
     crocksdb_env_t* env, const char* path, const crocksdb_envoptions_t* opts,
     char** errptr) {

--- a/librocksdb_sys/crocksdb/crocksdb/c.h
+++ b/librocksdb_sys/crocksdb/crocksdb/c.h
@@ -1782,6 +1782,8 @@ extern C_ROCKSDB_LIBRARY_API crocksdb_envoptions_t*
 crocksdb_envoptions_create();
 extern C_ROCKSDB_LIBRARY_API void crocksdb_envoptions_destroy(
     crocksdb_envoptions_t* opt);
+extern C_ROCKSDB_LIBRARY_API void crocksdb_envoptions_set_use_direct_writes(
+    crocksdb_envoptions_t* opt, unsigned char v);
 
 extern C_ROCKSDB_LIBRARY_API crocksdb_sequential_file_t*
 crocksdb_sequential_file_create(crocksdb_env_t* env, const char* path,

--- a/librocksdb_sys/src/lib.rs
+++ b/librocksdb_sys/src/lib.rs
@@ -1864,6 +1864,7 @@ extern "C" {
     // EnvOptions
     pub fn crocksdb_envoptions_create() -> *mut EnvOptions;
     pub fn crocksdb_envoptions_destroy(opt: *mut EnvOptions);
+    pub fn crocksdb_envoptions_set_use_direct_writes(opt: *mut EnvOptions, v: bool);
 
     // SequentialFile
     pub fn crocksdb_sequential_file_create(

--- a/src/rocksdb_options.rs
+++ b/src/rocksdb_options.rs
@@ -1489,6 +1489,16 @@ impl ColumnFamilyOptions {
         }
     }
 
+    /// Read this options' files with O_DIRECT, bypassing the OS page cache.
+    /// Useful for a standalone SstFileReader (e.g. ingest checksum verification)
+    /// so a one-shot read does not populate the page cache. `DBOptions` exposes
+    /// the same setter; both write to the shared underlying options object.
+    pub fn set_use_direct_reads(&mut self, v: bool) {
+        unsafe {
+            crocksdb_ffi::crocksdb_options_set_use_direct_reads(self.inner, v);
+        }
+    }
+
     pub fn optimize_level_style_compaction(&mut self, memtable_memory_budget: i32) {
         unsafe {
             crocksdb_ffi::crocksdb_options_optimize_level_style_compaction(
@@ -2364,6 +2374,14 @@ impl EnvOptions {
             EnvOptions {
                 inner: crocksdb_ffi::crocksdb_envoptions_create(),
             }
+        }
+    }
+
+    /// Use O_DIRECT for writes through this EnvOptions (e.g. the SstFileWriter).
+    /// Affects only the write path; reads of the resulting file stay buffered.
+    pub fn set_use_direct_writes(&mut self, v: bool) {
+        unsafe {
+            crocksdb_ffi::crocksdb_envoptions_set_use_direct_writes(self.inner, v);
         }
     }
 }

--- a/tests/cases/test_ingest_external_file.rs
+++ b/tests/cases/test_ingest_external_file.rs
@@ -565,3 +565,44 @@ fn test_ingest_external_file_options() {
     ingest_opt.set_write_global_seqno(true);
     assert_eq!(true, ingest_opt.get_write_global_seqno());
 }
+
+#[test]
+fn test_sst_direct_io() {
+    let dir = tempdir_with_prefix("_rust_rocksdb_test_sst_direct_io");
+    let sst_path = dir.path().join("sst");
+    let sst_path_str = sst_path.to_str().unwrap();
+    let expected = vec![
+        (b"k1".to_vec(), b"a".to_vec()),
+        (b"k2".to_vec(), b"b".to_vec()),
+        (b"k3".to_vec(), b"c".to_vec()),
+    ];
+
+    // Write the SST bypassing the OS page cache.
+    let mut env_opt = EnvOptions::new();
+    env_opt.set_use_direct_writes(true);
+    let mut writer = SstFileWriter::new(env_opt, ColumnFamilyOptions::new());
+    writer.open(sst_path_str).unwrap();
+    for &(ref k, ref v) in &expected {
+        writer.put(k, v).unwrap();
+    }
+    writer.finish().unwrap();
+
+    // Read it back bypassing the page cache too.
+    let mut cf_opt = ColumnFamilyOptions::new();
+    cf_opt.set_use_direct_reads(true);
+    let mut reader = SstFileReader::new(cf_opt);
+    reader.open(sst_path_str).unwrap();
+    reader.verify_checksum().unwrap();
+    let mut it = reader.iter();
+    it.seek(SeekKey::Start).unwrap();
+    assert_eq!(it.collect::<Vec<_>>(), expected);
+
+    // A directly-written SST must remain a well-formed, ordinary SST: the
+    // alignment padding O_DIRECT requires must not leak into the file format.
+    let mut reader = SstFileReader::new(ColumnFamilyOptions::new());
+    reader.open(sst_path_str).unwrap();
+    reader.verify_checksum().unwrap();
+    let mut it = reader.iter();
+    it.seek(SeekKey::Start).unwrap();
+    assert_eq!(it.collect::<Vec<_>>(), expected);
+}


### PR DESCRIPTION
### What is changed and how it works?

See https://github.com/tikv/tikv/issues/19917 for full context. Exposes two direct-IO setters that TiKV needs in order to stop its SST importer from polluting the OS page cache:

- **`EnvOptions::set_use_direct_writes`** — lets `SstFileWriter` write an SST without
  populating the page cache. Adds the missing `crocksdb_envoptions_set_use_direct_writes`
  shim; RocksDB already supports the underlying `EnvOptions::use_direct_writes`, using
  `O_DIRECT` on Linux and `fcntl(F_NOCACHE)` on macOS.
- **`ColumnFamilyOptions::set_use_direct_reads`** — lets a standalone `SstFileReader` read an
  SST the same way. Rust-only wrapper; it reuses the existing
  `crocksdb_options_set_use_direct_reads` FFI, so there is no new C code on this path.

Neither setter changes any default — both are `false` unless explicitly set, so existing
users are unaffected.

### Check List

Tests

- [x] Unit test — `test_sst_direct_io` in `tests/cases/test_ingest_external_file.rs`: writes
      an SST with direct writes, reads it back with direct reads and verifies checksum +
      contents, then reads it once more *buffered* to confirm the alignment padding
      `O_DIRECT` requires does not leak into the file format.

Side effects

- [ ] Performance regression
- [ ] Breaking backward compatibility

No behaviour change unless a caller opts in.

### Related changes

- Consumed by a follow-up PR to `tikv/tikv` implementing the importer fix; that PR is blocked
  on this one landing, since TiKV pins `rocksdb` by git.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added options to enable direct reads for column families.
  - Added options to enable direct writes for environment settings.
  - Direct I/O supports creating, verifying, and reading SST files normally.

- **Tests**
  - Added coverage confirming direct I/O preserves expected SST contents and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->